### PR TITLE
Add project specifications and brand assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+
+# Environment variables
+.env
+.env.*
+!.env.example
+
+# TypeScript
+*.tsbuildinfo
+
+# Testing
+coverage/
+
+# Playwright
+playwright-report/
+test-results/
+
+# Docker
+.docker/
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+!*.tfvars.example
+.terraform.lock.hcl
+
+# IDE
+.vscode/
+!.vscode/extensions.json
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,142 @@
-# mars-mission-fund
-A sample repo for coding workshops. A fake product for crowd funding projects that help get us to Mars
+# Mars Mission Fund
+
+<div align="center">
+
+<img src="assets/logo.svg" alt="Mars Mission Fund coin logo" width="160">
+
+![Mars Mission Fund](https://img.shields.io/badge/MARS_MISSION_FUND-FF5C1A?style=for-the-badge&labelColor=0B1628)
+
+A sample crowdfunding application for coding workshops.
+Mars Mission Fund is a fictional product that channels collective capital toward missions, technologies, and teams taking humanity to Mars.
+
+The project is designed to teach software engineering practices using production-grade specifications, architecture patterns, and development workflows.
+
+![TypeScript](https://img.shields.io/badge/TypeScript-FF8C42?style=flat-square&labelColor=0E2040&logo=typescript&logoColor=FF8C42)
+![React](https://img.shields.io/badge/React_19-FF8C42?style=flat-square&labelColor=0E2040&logo=react&logoColor=FF8C42)
+![Node.js](https://img.shields.io/badge/Node_22_LTS-FF8C42?style=flat-square&labelColor=0E2040&logo=node.js&logoColor=FF8C42)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-FF8C42?style=flat-square&labelColor=0E2040&logo=postgresql&logoColor=FF8C42)
+![Docker](https://img.shields.io/badge/Docker-FF8C42?style=flat-square&labelColor=0E2040&logo=docker&logoColor=FF8C42)
+
+</div>
+
+---
+
+## What This Repo Contains
+
+- **Product specifications** covering vision, brand, engineering standards, architecture, security, and domain workflows (see [specs/README.md](./specs/README.md))
+- **Application source code** for a TypeScript full-stack crowdfunding platform
+- **Infrastructure configuration** for local development via Docker Compose
+
+The specifications are intentionally production-grade.
+They serve as working documentation and as templates demonstrating how real-world specs should be structured.
+Each spec includes a "Local demo scope" note identifying what matters for the workshop versus what is theatre.
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+| ----- | ---------- |
+| ![Lang](https://img.shields.io/badge/Language-0E2040?style=flat-square) | TypeScript (frontend and backend) |
+| ![Runtime](https://img.shields.io/badge/Runtime-0E2040?style=flat-square) | Node.js 22.x LTS |
+| ![Frontend](https://img.shields.io/badge/Frontend-0E2040?style=flat-square) | React 19.x |
+| ![Backend](https://img.shields.io/badge/Backend-0E2040?style=flat-square) | Express 5.x |
+| ![Database](https://img.shields.io/badge/Database-0E2040?style=flat-square) | PostgreSQL 16.11 (Aurora in production, Docker locally) |
+| ![Arch](https://img.shields.io/badge/Architecture-0E2040?style=flat-square) | Hexagonal (Ports and Adapters), CQRS / Event Sourcing |
+| ![Testing](https://img.shields.io/badge/Testing-0E2040?style=flat-square) | Vitest, Playwright, Testing Library, SuperTest |
+| ![Auth](https://img.shields.io/badge/Auth-0E2040?style=flat-square) | Clerk |
+| ![Payments](https://img.shields.io/badge/Payments-0E2040?style=flat-square) | Stripe (stubbed locally) |
+
+For the full technology inventory, see [specs/tech/tech-stack.md](./specs/tech/tech-stack.md).
+
+---
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 22.x LTS
+- [npm](https://www.npmjs.com/) 10.x
+- [Docker](https://www.docker.com/) and Docker Compose
+- Git
+
+---
+
+## Getting Started
+
+```bash
+# Clone the repository
+git clone https://github.com/LeeCampbell/mars-missionfund.git
+cd mars-mission-fund
+
+# Install dependencies
+npm install
+
+# Start local infrastructure (PostgreSQL, etc.)
+docker compose up -d
+
+# Run database migrations
+npm run migrate
+
+# Start the development server
+npm run dev
+```
+
+> **Note:** External services (Stripe, Clerk, Veriff, AWS SES) are stubbed or mocked for local development.
+> See `.env.example` for required environment variables.
+
+---
+
+## Project Structure
+
+```text
+specs/              Product and technical specifications (start here)
+src/                Application source code
+e2e/                Playwright end-to-end tests
+```
+
+---
+
+## Specifications
+
+The [specs/](./specs/) directory contains a layered specification system:
+
+| Layer | Scope | Specs |
+| ----- | ----- | ----- |
+| ![L1](https://img.shields.io/badge/L1-STRATEGIC-FF5C1A?style=flat-square&labelColor=0B1628) | Product vision and mission | 1 spec |
+| ![L2](https://img.shields.io/badge/L2-STANDARDS-FF8C42?style=flat-square&labelColor=0B1628) | Brand and engineering standards | 2 specs |
+| ![L3](https://img.shields.io/badge/L3-TECHNICAL-1A3A6E?style=flat-square&labelColor=0B1628) | Architecture, security, frontend, data, audit, tech stack | 8 specs |
+| ![L4](https://img.shields.io/badge/L4-DOMAIN-FFB347?style=flat-square&labelColor=0B1628) | Account, campaign, donor, payments, KYC workflows | 5 specs |
+
+Read [specs/README.md](./specs/README.md) before implementing any feature.
+It includes the full dependency graph, agent protocol, and cross-cutting concern index.
+
+---
+
+## Quality Gates
+
+- Unit test coverage: 80%+ required
+- Integration tests must pass
+- E2E tests must pass
+- ESLint and Prettier enforced
+- Markdown linting via markdownlint-cli2
+
+---
+
+## Contributing
+
+- Do not commit directly to `main` -- use feature branches
+- Branch naming: `feat/`, `fix/`, `chore/` prefixes
+- Push feature branches and open PRs against `main`
+
+---
+
+## Licence
+
+This project is for educational purposes as part of a coding workshop.
+
+---
+
+<div align="center">
+
+![Mars Mission Fund](https://img.shields.io/badge/EVERY_DOLLAR_MOVES_THE_LAUNCH_WINDOW_CLOSER-0B1628?style=for-the-badge&labelColor=FF5C1A)
+
+</div>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,45 @@
+<svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="coinGrad" cx="35%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#E8EDF5"/>
+      <stop offset="40%" stop-color="#C8D0DC"/>
+      <stop offset="75%" stop-color="#8A96A8"/>
+      <stop offset="100%" stop-color="#5A6475"/>
+    </radialGradient>
+    <radialGradient id="coinInner" cx="40%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#1A3A6E"/>
+      <stop offset="50%" stop-color="#0B1628"/>
+      <stop offset="100%" stop-color="#060A14"/>
+    </radialGradient>
+    <radialGradient id="marsGrad" cx="40%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#FF8C42"/>
+      <stop offset="45%" stop-color="#C1440E"/>
+      <stop offset="100%" stop-color="#7A2A0A"/>
+    </radialGradient>
+  </defs>
+  <!-- Outer ring -->
+  <circle cx="60" cy="60" r="58" fill="url(#coinGrad)" opacity="0.3"/>
+  <!-- Coin body -->
+  <circle cx="60" cy="60" r="52" fill="url(#coinGrad)"/>
+  <!-- Inner recess -->
+  <circle cx="60" cy="60" r="44" fill="url(#coinInner)"/>
+  <!-- Ridge detail -->
+  <circle cx="60" cy="60" r="48" fill="none" stroke="rgba(200,208,220,0.15)" stroke-width="1"/>
+  <circle cx="60" cy="60" r="46" fill="none" stroke="rgba(200,208,220,0.08)" stroke-width="0.5"/>
+  <!-- Mars planet -->
+  <circle cx="60" cy="60" r="24" fill="url(#marsGrad)"/>
+  <!-- Mars surface details -->
+  <ellipse cx="52" cy="56" rx="5" ry="3" fill="rgba(90,30,10,0.5)" transform="rotate(-15,52,56)"/>
+  <ellipse cx="68" cy="58" rx="4" ry="2" fill="rgba(90,30,10,0.4)" transform="rotate(10,68,58)"/>
+  <ellipse cx="60" cy="50" rx="7" ry="2.5" fill="rgba(255,140,66,0.4)" transform="rotate(-5,60,50)"/>
+  <ellipse cx="57" cy="68" rx="3" ry="2" fill="rgba(90,30,10,0.3)" transform="rotate(20,57,68)"/>
+  <!-- Mars polar cap -->
+  <ellipse cx="60" cy="38" rx="6" ry="2.5" fill="rgba(220,230,245,0.4)"/>
+  <!-- Orbital ring -->
+  <ellipse cx="60" cy="60" rx="32" ry="10" fill="none" stroke="rgba(200,208,220,0.25)" stroke-width="1" stroke-dasharray="3 2" transform="rotate(-25,60,60)"/>
+  <!-- Coin shine highlight -->
+  <ellipse cx="46" cy="36" rx="14" ry="8" fill="rgba(255,255,255,0.12)" transform="rotate(-20,46,36)"/>
+  <!-- Star details in rim -->
+  <text x="60" y="15" text-anchor="middle" font-size="7" fill="rgba(200,208,220,0.4)" font-family="serif" font-weight="bold">&#x2605;</text>
+  <text x="60" y="109" text-anchor="middle" font-size="7" fill="rgba(200,208,220,0.4)" font-family="serif" font-weight="bold">&#x2605;</text>
+</svg>

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,219 @@
+# Mars Mission Fund — Specification Index
+
+> **Read this file first.**
+This is the authoritative index of all specifications governing the Mars Mission Fund platform.
+Before implementing any task, identify which specs govern the affected domain and read them in layer order (L1 → L4).
+
+---
+
+## Workshop Context
+
+Mars Mission Fund is a **sample application for a coding workshop** — a fictional product used to teach software engineering practices.
+These specifications are written to production standard as a deliberate part of the exercise: participants learn to work with real-world specification patterns, architectural trade-offs, and cross-cutting concerns.
+
+**What is real (impacts the local demo)**:
+
+- Tech stack choices, architecture patterns, and CQRS/Event Sourcing (L3-001, L3-008).
+- Frontend standards, component architecture, and brand tokens (L2-001, L3-005).
+- Domain workflows and acceptance criteria that drive implementation (L4 specs).
+- Code quality gates, testing standards, and linting (L2-002, L3-007).
+- Audit event schema and event store design (L3-006).
+
+**What is theatre (production-realistic but not implemented locally)**:
+
+- Multi-environment deployment (staging, production) — local Docker only.
+- Disaster recovery, failover, on-call rotations, and SLA enforcement (L3-003).
+- Penetration testing, security incident response, and breach notification (L3-002).
+- PCI DSS compliance processes, GDPR operational workflows (L3-002, L3-006).
+- Data residency, cross-border transfers, and tiered storage automation (L3-004, L3-006).
+- External provider integrations (KYC, payment gateway, email, search) — stubbed or mocked.
+- Secrets management service, certificate management — environment variables for local dev.
+
+The specifications are intentionally production-grade.
+They serve as working documentation for the demo and as templates demonstrating how real-world specs should be structured.
+Each spec includes a **Local demo scope** note identifying what matters for the workshop.
+
+---
+
+## Agent Protocol
+
+1. **Before any implementation task**, read this index to identify governing specs.
+1. **Read specs top-down**: L1 → L2 → relevant L3 → relevant L4. Higher layers take precedence.
+1. **Never contradict a higher-layer spec.** If a lower-layer spec conflicts with a higher one, flag it as a blocking issue and reference both documents.
+1. **Cross-reference dependencies.** Each spec lists what it depends on and what depends on it. Follow these links to ensure changes don't break downstream specs.
+1. **Check rate of change.** Specs with a slow rate of change require change request approval before modification. Specs with a fast rate of change can be updated with standard review.
+
+---
+
+## Specification Hierarchy
+
+### L1 — Strategic (changes quarterly or at major pivots)
+
+| Spec ID | Document | Purpose | Status |
+| ------- | -------- | ------- | ------ |
+| L1-001 | `product-vision-and-mission.md` | Root document. Defines why we exist, who we serve, what we build, and what we don't. All other specs must align with the vision, mission, principles, and scope boundaries defined here. | Approved |
+
+**Governance**: Changes to L1 require product leadership approval and trigger a review of all downstream specs for alignment.
+
+---
+
+### L2 — Standards (changes monthly or at standard reviews)
+
+| Spec ID | Document | Purpose | Depends On | Status |
+| ------- | -------- | ------- | ---------- | ------ |
+| L2-001 | `standards/brand.md` | How the MMF brand system (colours, typography, voice, motion) is applied within the product. References the HTML brand guidelines as the source of truth for design tokens. Specifies product-specific application rules, component-to-token mappings, accessibility requirements, and voice-in-product patterns. Does not duplicate brand guidelines. | L1-001, Brand Guidelines (HTML) | Approved |
+| L2-002 | `standards/engineering.md` | The engineering constitution. Codifies non-negotiable technical decisions: security-first architecture, parameterised queries only, encryption standards, testing requirements, code quality gates, and dependency management policies. All L3 and L4 specs inherit these constraints. | L1-001 | Approved |
+
+**Governance**: Changes to L2 require engineering and design leadership review. Changes to L2-002 trigger a review of all L3 specs.
+
+---
+
+### L3 — Technical (changes at sprint level / technology decisions)
+
+| Spec ID | Document | Purpose | Depends On | Status |
+| ------- | -------- | ------- | ---------- | ------ |
+| L3-001 | `tech/architecture.md` | System architecture, service boundaries, data model, infrastructure design, deployment topology, and inter-service communication patterns. | L1-001, L2-002, L3-008 | Approved |
+| L3-002 | `tech/security.md` | Threat model, control matrix, authentication/authorisation architecture, encryption standards, compliance mapping (PCI DSS, GDPR, Australian Privacy Act). Implements the "Security as Foundation" principle from L1-001. | L1-001, L2-002, L3-001 | Approved |
+| L3-003 | `tech/reliability.md` | Availability targets, failover strategies, disaster recovery, backup policies, circuit breakers, health checks, and degradation modes. | L2-002, L3-001 | Approved |
+| L3-004 | `tech/data-management.md` | Data classification scheme, retention policies, data lifecycle, anonymisation rules, backup and recovery, data access patterns, and migration strategies. | L2-002, L3-001, L3-002 | Approved |
+| L3-005 | `tech/frontend.md` | Frontend architecture, component library standards, performance budgets, accessibility (WCAG 2.1 AA minimum), responsive breakpoints, animation performance constraints, and browser support matrix. Implements brand tokens defined in L2-001. | L2-001, L2-002, L3-001 | Approved |
+| L3-006 | `tech/audit.md` | Audit logging architecture, immutable event streams, what gets logged, retention periods, access controls on audit data, regulatory reporting, and anomaly detection. Implements the "Transparency as Currency" principle from L1-001. | L1-001, L2-002, L3-001, L3-002 | Approved |
+| L3-007 | `tech/markdown.md` | Markdown authorship standard: one-sentence-per-line rule, heading and list conventions, linter configuration (markdownlint). Governs all `.md` files in the repository. | L2-002 | Approved |
+| L3-008 | `tech/tech-stack.md` | Enumerates all technology choices: languages, frameworks, libraries, infrastructure, and tooling. Single source of truth for the platform's technology baseline. | L1-001, L2-002, L3-001 | Approved |
+
+**Governance**: Changes to L3 specs require engineering review. Changes to L3-001 (architecture) or L3-002 (security) trigger review of all dependent L3 and L4 specs.
+
+---
+
+### L4 — Domain (changes per feature / per release)
+
+| Spec ID | Document | Purpose | Depends On | Status |
+| ------- | -------- | ------- | ---------- | ------ |
+| L4-001 | `domain/account.md` | The full account lifecycle: registration, onboarding, email verification, password policies, SSO integration, profile management, role assignment, session management, notification preferences, account recovery, account deactivation, and data portability. Onboarding is a phase within this lifecycle, not a separate concern. | L2-001, L3-002, L3-005, L4-005 | Approved |
+| L4-002 | `domain/campaign.md` | Full campaign lifecycle: project submission, review pipeline, approval/rejection, live campaign management, funding progress tracking, milestone definition and verification, stretch goals, deadline enforcement, campaign completion, campaign failure handling, and fund settlement. Origination is a phase within this lifecycle, not a separate concern. | L1-001, L2-001, L3-001, L3-006, L4-004 | Approved |
+| L4-003 | `domain/donor.md` | The complete donor-side bounded context: project discovery and search, recommendation engine, curated collections, category browsing, contribution flow (references L4-004), ongoing donor relationship management, contribution history, impact reporting, milestone notifications, cumulative impact dashboards, and repeat engagement patterns. Implements the "Accessibility Over Exclusivity" principle from L1-001. | L1-001, L2-001, L3-005, L4-002, L4-004 | Approved |
+| L4-004 | `domain/payments.md` | Payment processing: gateway integration (Stripe), tokenisation, PCI DSS scope management (SAQ-A), escrow mechanics, milestone-based disbursement, multi-approval disbursement workflows, refund handling, currency support, transaction reconciliation, tax receipt generation, and financial reporting. | L2-002, L3-001, L3-002, L3-004, L3-006 | Approved |
+| L4-005 | `domain/kyc.md` | Identity verification: KYC document upload, automated verification checks, sanctions screening, manual review workflows, verification status lifecycle, re-verification triggers, jurisdictional requirements, and data retention rules specific to identity documents. | L2-002, L3-002, L3-004, L3-006 | Approved |
+
+**Governance**: Changes to L4 specs follow standard feature review. Changes that affect interfaces between domain specs require review of all connected specs (check "Depends On" chains).
+
+---
+
+### Tooling
+
+Operational references and CLI cheat-sheets.
+These are not numbered specs and do not participate in the L1–L4 dependency hierarchy.
+
+| Document | Purpose |
+|----------|---------|
+| `tooling/github.md` | CLI reference for managing GitHub milestones, issues, and PRs via `gh`. |
+
+---
+
+## Dependency Graph (Summary)
+
+```text
+L1-001 Product Vision & Mission
+│
+├── L2-001 standards/brand.md
+│   ├── L3-005 tech/frontend.md
+│   │   ├── L4-001 domain/account.md
+│   │   ├── L4-002 domain/campaign.md
+│   │   └── L4-003 domain/donor.md
+│   ├── L4-001 domain/account.md
+│   ├── L4-002 domain/campaign.md
+│   └── L4-003 domain/donor.md
+│
+├── L2-002 standards/engineering.md
+│   ├── L3-001 tech/architecture.md
+│   │   ├── L3-002 tech/security.md
+│   │   │   ├── L3-004 tech/data-management.md
+│   │   │   ├── L3-006 tech/audit.md
+│   │   │   ├── L4-001 domain/account.md
+│   │   │   ├── L4-004 domain/payments.md
+│   │   │   └── L4-005 domain/kyc.md
+│   │   ├── L3-003 tech/reliability.md
+│   │   ├── L3-004 tech/data-management.md
+│   │   │   ├── L4-004 domain/payments.md
+│   │   │   └── L4-005 domain/kyc.md
+│   │   ├── L3-005 tech/frontend.md
+│   │   └── L3-006 tech/audit.md
+│   │       ├── L4-002 domain/campaign.md
+│   │       ├── L4-004 domain/payments.md
+│   │       └── L4-005 domain/kyc.md
+│   ├── L4-004 domain/payments.md
+│   └── L4-005 domain/kyc.md
+│
+├── L3-006 tech/audit.md
+├── L4-002 domain/campaign.md
+└── L4-003 domain/donor.md
+```
+
+---
+
+## Cross-Cutting Concerns
+
+Some concerns span multiple specs. When working in these areas, read all referenced specs:
+
+| Concern | Governing Specs | Notes |
+| ------- | --------------- | ----- |
+| Payment security | L3-002, L3-006, L4-004, L4-005 | PCI DSS compliance touches security, audit, payments, and KYC |
+| User data privacy | L3-002, L3-004, L4-001, L4-005 | GDPR and Australian Privacy Act span security, data management, account, and KYC |
+| Campaign financial integrity | L3-006, L4-002, L4-004 | Escrow, milestone disbursement, and audit trail must be consistent |
+| Donor experience | L2-001, L3-005, L4-003, L4-004 | Brand standards, frontend standards, donor spec, and payments must deliver a cohesive flow |
+| Access control | L3-002, L4-001, L4-002, L4-005 | RBAC model defined in security, implemented across account, campaign review, and KYC workflows |
+
+---
+
+## File System Layout
+
+```text
+specs/
+├── README.md                          ← You are here
+├── product-vision-and-mission.md      ← L1
+├── standards/
+│   ├── brand.md                       ← L2-001
+│   └── engineering.md                 ← L2-002
+├── tech/
+│   ├── architecture.md                ← L3-001
+│   ├── security.md                    ← L3-002
+│   ├── reliability.md                 ← L3-003
+│   ├── data-management.md             ← L3-004
+│   ├── frontend.md                    ← L3-005
+│   ├── audit.md                       ← L3-006
+│   ├── markdown.md                    ← L3-007
+│   └── tech-stack.md                  ← L3-008
+├── tooling/
+│   └── github.md                      ← GitHub CLI reference
+└── domain/
+    ├── account.md                     ← L4-001
+    ├── campaign.md                    ← L4-002
+    ├── donor.md                       ← L4-003
+    ├── payments.md                    ← L4-004
+    └── kyc.md                         ← L4-005
+```
+
+---
+
+## Document Conventions
+
+All specs in this ecosystem follow these conventions:
+
+- **Spec ID**: Every document has a unique ID (e.g., L3-002) used for cross-referencing.
+- **Frontmatter metadata**: Each spec includes spec ID, version, status, rate of change, depends-on list, and depended-on-by list.
+- **Acceptance criteria**: L4 domain specs must include explicit, testable acceptance criteria for every workflow.
+- **Interface contracts**: Where specs share boundaries (e.g., payments ↔ campaign), both specs must define the interface contract and reference each other.
+- **Change log**: Every spec maintains a change log with date, author, and summary of changes.
+- **Status values**: `Not Started` → `Draft` → `Review` → `Approved` → `Superseded`
+
+---
+
+## External References
+
+| Reference | Type | Location | Notes |
+| --------- | ---- | -------- | ----- |
+| Brand Guidelines | Design system | `standards/mars-mission-fund-brand.html` | Source of truth for design tokens, colour palette, typography, voice & tone, motion. L2-001 references this; does not duplicate it. |
+
+---
+
+*This index is the entry point for all agents and contributors. Keep it current.*

--- a/specs/domain/account.md
+++ b/specs/domain/account.md
@@ -1,0 +1,439 @@
+# Account Lifecycle
+
+> **Spec ID**: L4-001
+> **Version**: 0.2
+> **Status**: Approved
+> **Rate of Change**: Per feature / per release
+> **Depends On**: L2-001 (Brand Application Standard), L3-002 (Security), L3-005 (Frontend Standards), L4-005 (KYC)
+> **Depended On By**: L4-002 (Campaign), L4-003 (Donor), L4-004 (Payments)
+
+---
+
+## Purpose
+
+> **Local demo scope**: Registration, authentication via Clerk, role assignment, and profile management are **real** — they are implemented in the local demo. Session elevation, MFA enforcement, account deactivation with GDPR erasure workflow, data portability exports, and SSO provider integration are theatre. The local demo uses Clerk's default session management.
+
+This spec governs the full account lifecycle for Mars Mission Fund: registration, onboarding, email verification, password policies, SSO integration, profile management, role assignment and management, session management, notification preferences, account recovery, account deactivation, and data portability.
+
+Onboarding is a phase within the account lifecycle, not a separate domain concern.
+
+**This spec does NOT cover**:
+
+- Identity verification and KYC document handling — governed by [KYC](L4-005).
+- Payment methods and financial instruments — governed by [Payments](L4-004).
+- Campaign creation or management workflows — governed by [Campaign](L4-002).
+- Donor-specific features (discovery, contribution history, impact dashboards) — governed by [Donor](L4-003).
+
+**Boundary rule**: This spec owns the identity, authentication state, role assignments, and profile data of a user.
+Other domain specs consume account identity context through the interface contracts defined in Section 8.
+
+---
+
+## Inherited Constraints
+
+### From [Engineering Standard](L2-002)
+
+- **Section 1.1 (Encryption)**: All authentication credentials and personal data encrypted at rest (AES-256) and in transit (TLS 1.3 minimum).
+- **Section 1.2 (Data Access)**: All account data queries use parameterised queries via the data access layer.
+- **Section 1.3 (Secrets Management)**: Authentication secrets (OAuth client secrets, signing keys) managed via secrets management service, never in source code.
+- **Section 1.4 (Input Validation)**: All registration and profile input validated and sanitised at the system boundary.
+- **Section 1.5 (Authentication & Authorisation)**: Every endpoint authenticated and authorised. MFA required for administrative operations and financial actions.
+- **Section 1.7 (Logging & Auditability)**: Every account state mutation logged with timestamp, actor, action, and affected resource.
+- **Section 3.4 (Code Review)**: Security-surface changes (authentication, authorisation, session management) require a second reviewer with security domain expertise.
+- **Section 4.2 (Test Coverage)**: 100% coverage of roles and permission combinations via integration tests. 100% coverage of authentication flows.
+- **Section 5.3 (Error Response Contract)**: Account-related errors follow the standard error format with machine-readable codes, human-readable messages per [Brand Application Standard](L2-001) voice patterns, and correlation IDs.
+
+### From [Security](L3-002)
+
+- Authentication and authorisation architecture as defined in L3-002.
+- Session policies (token lifetimes, refresh mechanics, revocation) as defined in L3-002.
+- MFA implementation standards (TOTP, WebAuthn) as defined in L3-002.
+- Password hashing algorithm and policy parameters as defined in L3-002.
+- RBAC model and permission matrix as defined in L3-002.
+
+### From [Frontend Standards](L3-005)
+
+- All account UI surfaces comply with WCAG 2.1 AA minimum.
+- All form inputs, buttons, and interactive elements use semantic tokens from [Brand Application Standard](L2-001).
+- Registration and onboarding flows meet performance budgets defined in L3-005.
+- Responsive breakpoints and browser support matrix as defined in L3-005.
+
+### From [KYC](L4-005)
+
+- KYC verification status lifecycle feeds back into account state (see Section 8.1).
+- Account cannot access certain role-gated features until KYC status is verified, as defined in L4-005.
+
+---
+
+## 1. Registration
+
+### 1.1 Email/Password Registration
+
+Users may register with an email address and password.
+
+- Email address must be validated for format at the client and server boundary.
+- A verification email is sent immediately upon registration.
+- The account enters `Pending Verification` state until the email link is confirmed.
+- Verification links expire after 24 hours.
+- Users may request a new verification email if the link expires or is lost.
+
+**Password policies** (exact parameters to be defined in [Security](L3-002)):
+
+- Minimum length, complexity requirements, and breach-list checking as defined in L3-002.
+- Passwords are hashed using the algorithm specified in L3-002. Plaintext passwords are never stored or logged.
+
+### 1.2 SSO Registration (OAuth 2.0 / OIDC)
+
+Users may register via a supported SSO provider using OAuth 2.0 / OpenID Connect.
+
+- Supported providers at launch: Google and Microsoft (via standard OIDC).
+- SSO registration creates an account with the email from the identity provider.
+- If an account with the same email already exists (from email/password registration), the user is prompted to link accounts rather than creating a duplicate.
+- SSO tokens are stored securely per [Security](L3-002) and [Engineering Standard](L2-002) Section 1.3.
+
+### 1.3 Registration State Machine
+
+```text
+[Start] → Pending Verification → Active → Deactivated → Deleted
+                ↑                  ↓ ↑          (auto after 90 days)
+           Verification      Suspended
+             Resent            ↓
+                            Active (on reinstatement)
+
+Active → Deleted  (direct GDPR erasure request)
+```
+
+- `Pending Verification`: Email not yet confirmed. Limited access (cannot perform financial actions or access role-gated features).
+- `Active`: Email confirmed. Full access per assigned roles.
+- `Suspended`: Administratively suspended (e.g., fraud review, KYC failure). No access. Requires Administrator action to reinstate.
+- `Deactivated`: User-initiated deactivation. Account data retained per retention policy. May be reactivated within 90 days; after 90 days, auto-transitions to `Deleted`.
+- `Deleted`: Data erased per GDPR right-to-erasure process (see Section 7).
+
+### Acceptance Criteria — Registration
+
+**AC-ACCT-001**: Given a new user, when they submit a valid email and password, then an account is created in `Pending Verification` state and a verification email is sent.
+
+**AC-ACCT-002**: Given a new user, when they submit an email that is already registered, then no new account is created and the user is informed that the email is in use (without revealing whether it is an SSO or password account, to prevent enumeration).
+
+**AC-ACCT-003**: Given a user in `Pending Verification` state, when they click the verification link within the expiry window, then the account transitions to `Active` state.
+
+**AC-ACCT-004**: Given a user in `Pending Verification` state, when the verification link has expired, then clicking it shows an error with an option to resend.
+
+**AC-ACCT-005**: Given a new user, when they register via a supported SSO provider, then an account is created in `Active` state (email already verified by the identity provider).
+
+**AC-ACCT-006**: Given a user registering via SSO, when an account with the same email already exists, then the user is prompted to link the SSO identity to their existing account (after re-authenticating with the existing method).
+
+---
+
+## 2. Onboarding
+
+Onboarding is the first-run experience that follows successful registration and email verification.
+It is not a separate domain — it is a phase within the account lifecycle.
+
+### 2.1 Onboarding Flow
+
+The onboarding flow guides new users through initial setup:
+
+1. **Welcome screen** — Brand-appropriate welcome message per [Brand Application Standard](L2-001) Section 4 voice patterns.
+1. **Role selection** — User selects their primary intent (Backer, Creator, or both). This does not permanently lock role assignment (see Section 3).
+1. **Progressive profiling** — Collects optional profile information (display name, avatar, bio). Non-blocking — the user can skip and complete later.
+1. **KYC trigger** (conditional) — If the selected role requires KYC verification (Creator), the onboarding flow triggers the KYC process as defined in [KYC](L4-005). The user is informed of the requirement and can begin or defer.
+1. **Notification preferences** — Initial notification opt-in/opt-out. All categories default to opt-in except platform announcements (opt-out). Security alerts are always on.
+1. **Completion** — User lands on the appropriate home surface based on selected role.
+
+### 2.2 Onboarding State
+
+- Onboarding progress is tracked per-account.
+- Users who abandon onboarding mid-flow can resume where they left off on next login.
+- Onboarding is considered complete when the user has selected a role and reached the home surface. Profile completion and KYC are not gates to onboarding completion.
+
+### Acceptance Criteria — Onboarding
+
+**AC-ACCT-007**: Given a newly verified user, when they log in for the first time, then they are presented with the onboarding flow.
+
+**AC-ACCT-008**: Given a user in onboarding, when they select the Creator role, then a KYC verification prompt is displayed with the option to begin or defer.
+
+**AC-ACCT-009**: Given a user who abandoned onboarding, when they log in again, then they resume from the step where they left off.
+
+**AC-ACCT-010**: Given a user in onboarding, when they skip optional profiling steps, then onboarding completes and the user reaches the home surface.
+
+---
+
+## 3. Role Assignment and Management
+
+Mars Mission Fund defines five roles as specified in the Product Vision & Mission (L1-001):
+
+| Role | Description |
+| ---- | ----------- |
+| **Backer** | Can browse campaigns, make contributions, view contribution history and impact dashboards. Default role for all registered users. |
+| **Creator** | Can submit campaign proposals, manage campaigns, define milestones. Requires KYC verification. |
+| **Reviewer** | Can review submitted campaigns, approve or reject proposals, verify milestones. Assigned by Administrator. |
+| **Administrator** | Can manage users, assign roles, suspend accounts, configure platform settings. Assigned by Super Administrator. |
+| **Super Administrator** | Full platform access. Can assign Administrator roles, manage system configuration, access audit logs. Provisioned through a controlled process (not self-assignable). |
+
+### 3.1 Role Rules
+
+- Every account has the **Backer** role by default upon reaching `Active` state.
+- A user may hold multiple roles simultaneously (e.g., Backer + Creator).
+- **Creator** role requires KYC verification status of `Verified` from [KYC](L4-005). The role may be assigned before KYC is complete, but Creator-gated features are inaccessible until verification succeeds.
+- **Reviewer** and **Administrator** roles are assigned by an Administrator or Super Administrator.
+- **Super Administrator** role is provisioned through a controlled process defined in [Security](L3-002). It cannot be self-assigned or assigned through the standard UI.
+- Role changes are logged as state mutations per [Engineering Standard](L2-002) Section 1.7.
+- Removing a role from a user immediately revokes access to all features gated by that role.
+
+### Acceptance Criteria — Role Assignment
+
+**AC-ACCT-011**: Given a newly activated account, when the user reaches `Active` state, then the Backer role is automatically assigned.
+
+**AC-ACCT-012**: Given a user with Creator role but KYC status `Pending`, when they attempt to submit a campaign, then access is denied with a message directing them to complete KYC.
+
+**AC-ACCT-013**: Given an Administrator, when they assign the Reviewer role to a user, then the user gains access to the review pipeline and the role change is logged.
+
+**AC-ACCT-014**: Given an Administrator, when they attempt to assign the Super Administrator role, then the action is denied (Super Administrator provisioning is restricted).
+
+**AC-ACCT-015**: Given a user with the Creator role, when the role is removed, then all Creator-gated features become immediately inaccessible.
+
+---
+
+## 4. Profile Management
+
+### 4.1 Profile Data
+
+| Field | Required | Editable | Notes |
+| ----- | -------- | -------- | ----- |
+| Email | Yes | Yes (with re-verification) | Primary identifier. Change triggers verification of new email. |
+| Display name | No | Yes | Shown on public-facing surfaces (campaign pages, contribution lists). |
+| Avatar | No | Yes | File upload validated per [Engineering Standard](L2-002) Section 1.4. |
+| Bio | No | Yes | Free-text, sanitised on input. |
+| Notification preferences | Yes (defaults set) | Yes | See Section 4.2. |
+| Contribution history view | Read-only | N/A | Sourced from [Donor](L4-003). Displayed within account profile. |
+| KYC verification status | Read-only | N/A | Sourced from [KYC](L4-005). Displayed within account profile. |
+
+### 4.2 Notification Preferences
+
+Users can configure notification preferences for the following categories:
+
+- Campaign updates (for backed campaigns)
+- Milestone completions
+- Contribution confirmations
+- New campaign recommendations
+- Account security alerts (mandatory — cannot be disabled)
+- Platform announcements
+
+Each category supports channel selection (in-app, email) where applicable.
+
+**Rule**: Security-related notifications (login from new device, password change, MFA changes, suspicious activity) are always sent and cannot be disabled by the user.
+
+### Acceptance Criteria — Profile Management
+
+**AC-ACCT-016**: Given an authenticated user, when they update their display name, then the change is reflected on all public-facing surfaces and the update is logged.
+
+**AC-ACCT-017**: Given an authenticated user, when they change their email address, then a verification email is sent to the new address and the old email remains active until the new one is verified.
+
+**AC-ACCT-018**: Given an authenticated user, when they attempt to disable security notifications, then the option is not available (security notifications are mandatory).
+
+**AC-ACCT-019**: Given an authenticated user, when they upload an avatar, then the file is validated for type, size, and content per [Engineering Standard](L2-002) Section 1.4, and served from a separate domain.
+
+---
+
+## 5. Session Management
+
+Session management implements the policies defined in [Security](L3-002).
+This section defines the account-domain behaviour; the underlying mechanisms (token format, signing, storage) are governed by L3-002.
+
+### 5.1 Session Lifecycle
+
+- A session is created upon successful authentication (password login, SSO callback, or MFA completion).
+- Session tokens have a defined lifetime and refresh mechanism as specified in [Security](L3-002).
+- Sessions are bound to a single device/user-agent. Concurrent sessions across multiple devices are permitted.
+- Users can view and manage active sessions from their account settings.
+
+### 5.2 Session Revocation
+
+- A user may revoke any individual session or all sessions from account settings.
+- Password change or reset revokes all active sessions except the current one.
+- Administrative suspension revokes all active sessions immediately.
+- MFA recovery (see Section 6.2) revokes all active sessions.
+
+### 5.3 Elevated Sessions
+
+Certain actions require session elevation (re-authentication within the current session):
+
+- Changing email address
+- Changing password
+- Enrolling or removing MFA
+- Modifying roles (for Administrators)
+- Initiating account deactivation or deletion
+
+The elevation mechanism and timeout are defined in [Security](L3-002).
+
+### Acceptance Criteria — Session Management
+
+**AC-ACCT-020**: Given an authenticated user, when they view active sessions, then all sessions are listed with device, location (approximate), and last active time.
+
+**AC-ACCT-021**: Given an authenticated user, when they revoke a specific session, then that session is immediately invalidated and the corresponding device is logged out.
+
+**AC-ACCT-022**: Given a user who has changed their password, when they are on another device, then that device's session is revoked and requires re-authentication.
+
+**AC-ACCT-023**: Given a user performing an elevated action, when the session elevation has expired, then they are prompted to re-authenticate before proceeding.
+
+---
+
+## 6. Account Recovery
+
+### 6.1 Password Reset
+
+- User initiates reset from the login screen via "Forgot password".
+- A reset link is sent to the registered email address.
+- The reset link expires after 1 hour.
+- Submitting a valid reset link with a new password that meets policy requirements updates the password and revokes all existing sessions.
+- If MFA is enrolled, the password reset flow requires MFA confirmation before the new password takes effect.
+
+**Anti-enumeration**: The reset request endpoint must return the same response regardless of whether the email is registered, to prevent account enumeration.
+
+### 6.2 MFA Recovery
+
+If a user loses access to their MFA device:
+
+- Recovery codes (generated at MFA enrollment) can be used as a one-time bypass.
+- If recovery codes are exhausted, the user must contact support and complete manual identity verification: provide government-issued photo ID matching the account name, plus answer account-specific challenge questions. An Administrator reviews and approves the recovery. All MFA recovery events are audit-logged per [Audit](L3-006).
+- MFA recovery revokes all active sessions and requires the user to re-enrol MFA.
+
+### 6.3 Locked Account Process
+
+- After a configurable number of failed authentication attempts, the account is temporarily locked.
+- Lock duration and threshold are defined in [Security](L3-002).
+- The user is notified via email when their account is locked.
+- After the lock period expires, the user may attempt login again.
+- An Administrator can manually unlock an account.
+
+### Acceptance Criteria — Account Recovery
+
+**AC-ACCT-024**: Given a user who has forgotten their password, when they request a reset for a registered email, then a reset link is sent and the response does not reveal whether the email exists.
+
+**AC-ACCT-025**: Given a user with a valid reset link, when they submit a new password meeting policy requirements, then the password is updated and all other sessions are revoked.
+
+**AC-ACCT-026**: Given a user with MFA enrolled, when they use a recovery code, then they bypass MFA for that single authentication and the used code is invalidated.
+
+**AC-ACCT-027**: Given a user who has exceeded failed login attempts, when the threshold is reached, then the account is temporarily locked and a notification email is sent.
+
+**AC-ACCT-028**: Given a locked account, when the lock period expires, then the user can attempt authentication again.
+
+---
+
+## 7. Account Deactivation and Deletion
+
+### 7.1 User-Initiated Deactivation
+
+- A user may deactivate their account from account settings.
+- Deactivation requires session elevation (re-authentication).
+- Deactivation does not delete data. The account enters `Deactivated` state.
+- Active campaigns owned by the user must be resolved (completed, failed, or transferred) before deactivation is permitted.
+- Active contributions in escrow are not affected by deactivation (the escrow lifecycle continues per [Payments](L4-004)).
+- The user may reactivate within 90 days by logging in and confirming reactivation. After 90 days, the account transitions to `Deleted` and the GDPR erasure process (Section 7.2) is triggered automatically.
+
+### 7.2 GDPR Right-to-Erasure (Deletion)
+
+- A user may request full data deletion per GDPR Article 17.
+- Data deletion is processed per the data lifecycle and retention policies defined in [Data Management](L3-004).
+- The following data is erased: profile information, notification preferences, session history, and any PII associated with the account.
+- The following data is retained in anonymised form where legally required: contribution records (financial reporting obligations), audit log entries (regulatory compliance — see [Audit](L3-006)).
+- KYC documents are handled per the retention rules in [KYC](L4-005).
+- Deletion is irreversible. The user is warned and must confirm.
+- A confirmation email is sent when deletion is complete.
+
+### 7.3 Data Portability
+
+- Users may request an export of their personal data per GDPR Article 20.
+- The export includes: profile data, contribution history, notification preferences, and account activity.
+- Export format: both JSON and CSV. The user selects format at export request time.
+- Export generation is asynchronous. The user is notified when the export is ready for download.
+- Export download links expire after 48 hours and are secured per [Security](L3-002).
+
+### Acceptance Criteria — Deactivation and Deletion
+
+**AC-ACCT-029**: Given an authenticated user, when they deactivate their account, then the account enters `Deactivated` state and login is prevented.
+
+**AC-ACCT-030**: Given a user with active campaigns, when they attempt to deactivate, then they are informed that campaigns must be resolved first.
+
+**AC-ACCT-031**: Given a deactivated user, when they log in within the reactivation window, then they are prompted to reactivate and the account returns to `Active` state.
+
+**AC-ACCT-032**: Given a user requesting data deletion, when they confirm the request, then all PII is erased, anonymised records are retained per legal requirements, and a confirmation email is sent.
+
+**AC-ACCT-033**: Given a user requesting data export, when the export is generated, then they receive a notification with a time-limited secure download link containing their data in machine-readable format.
+
+**AC-ACCT-034**: Given a deactivated account, when 90 days have elapsed since deactivation, then the account automatically transitions to `Deleted` state and the GDPR erasure process (Section 7.2) is triggered.
+
+---
+
+## 8. Interface Contracts
+
+### 8.1 Account ↔ KYC ([KYC](L4-005))
+
+**Account → KYC**:
+
+- Account triggers the KYC process when a user selects or is assigned a role that requires verification (e.g., Creator).
+- Account provides the user identity context (account ID, email, name) to the KYC domain.
+- Account displays KYC verification status sourced from KYC.
+
+**KYC → Account**:
+
+- KYC publishes verification status changes (`Pending`, `In Review`, `Verified`, `Failed`, `Expired`) that Account consumes to gate role-specific features.
+- KYC failure or expiry may trigger account-level restrictions (Creator features locked until re-verification).
+
+**Contract**: Both domains reference the account ID as the shared identifier.
+Status changes are communicated via the event/messaging pattern defined in [Architecture](L3-001).
+
+### 8.2 Account ↔ Donor ([Donor](L4-003))
+
+**Account → Donor**:
+
+- Account provides identity context (account ID, display name, roles) consumed by the Donor domain for personalisation, contribution attribution, and recommendation engine inputs.
+
+**Donor → Account**:
+
+- Donor surfaces contribution history and impact data within the account profile (read-only, sourced from Donor domain).
+- Donor does not modify account state.
+
+**Contract**: Donor domain queries Account for identity context using the account ID.
+Contribution data displayed in the account profile is fetched from the Donor domain's read API.
+
+### 8.3 Account ↔ Campaign ([Campaign](L4-002))
+
+**Account → Campaign**:
+
+- Account provides role context (Creator, Reviewer, Administrator) that gates campaign workflows.
+- A user must have the Creator role and KYC `Verified` status to submit a campaign.
+- A user must have the Reviewer role to access the review pipeline.
+
+**Campaign → Account**:
+
+- Campaign references the account ID as the campaign owner (Creator).
+- Campaign does not modify account state.
+
+**Contract**: Campaign domain validates role and KYC status by querying Account at the point of action (campaign submission, review access).
+The specific API contract (endpoint, payload) is to be defined in implementation.
+
+### 8.4 Account ↔ Payments ([Payments](L4-004))
+
+**Account → Payments**:
+
+- Account provides the authenticated identity for payment operations.
+- Payment methods are managed within the Payments domain, not Account.
+
+**Payments → Account**:
+
+- Payments does not modify account state.
+- Active escrow status is checked during account deactivation (see Section 7.1).
+
+**Contract**: Payments domain receives the authenticated account ID from the session context.
+Escrow status queries during deactivation use the Payments read API.
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| ---- | ------- | ------ | ------- |
+| March 2026 | 0.1 | — | Initial stub. Registration, onboarding, roles, profile, sessions, recovery, deactivation, data portability, interface contracts with KYC, Donor, Campaign, and Payments. |
+| March 2026 | 0.2 | — | Resolved all open questions: verification link expiry (24h), password reset expiry (1h), SSO providers (Google, Microsoft), default notifications (all opt-in except announcements), reactivation window (90 days), export format (JSON + CSV), MFA recovery process (manual ID verification), no cooling-off period. |

--- a/specs/domain/campaign.md
+++ b/specs/domain/campaign.md
@@ -1,0 +1,488 @@
+# Campaign Lifecycle
+
+> **Spec ID**: L4-002
+> **Version**: 0.2
+> **Status**: Approved
+> **Rate of Change**: Per feature / per release
+> **Depends On**: L1-001 (Product Vision & Mission), L2-001 (standards/brand.md), L3-001 (tech/architecture.md), L3-006 (tech/audit.md), L4-004 (domain/payments.md), L4-005 (domain/kyc.md)
+> **Depended On By**: L4-003 (domain/donor.md)
+
+---
+
+## 1. Purpose
+
+> **Local demo scope**: The campaign state machine, submission flow, review pipeline, and milestone verification workflow are **real** — they are the core demo feature. Appeal processes, deadline enforcement automation, and stretch goal mechanics are theatre for the workshop. The local demo focuses on the happy path: Draft → Submitted → Under Review → Approved → Live → Funded → Settlement → Complete.
+
+This spec governs the full campaign lifecycle on Mars Mission Fund — from initial project submission through review, approval, live fundraising, milestone verification, and final settlement or failure handling.
+
+**What this spec covers**:
+
+- Campaign state machine and all valid transitions.
+- Project submission flow and required fields.
+- Review pipeline, curation criteria, and reviewer role assignment.
+- Approval, rejection, resubmission, and appeal processes.
+- Live campaign management: public page, funding progress, stretch goals, deadline enforcement.
+- Milestone definition, evidence submission, verification, and staged fund release.
+- Campaign completion and settlement workflow.
+- Campaign failure, deadline expiry, and refund triggers.
+
+**What this spec does NOT cover**:
+
+- Payment processing mechanics, escrow implementation, or refund execution — see [Payments](L4-004).
+- Donor discovery, search, recommendations, or contribution flow — see [Donor](L4-003).
+- Account registration, role management, or session management — see [Account](L4-001).
+- KYC verification — see [KYC](L4-005).
+- Audit log storage and retention architecture — see [Audit](L3-006).
+
+---
+
+## 2. Inherited Constraints
+
+### From [Engineering Standard](L2-002)
+
+- **Section 1.2 — Data Access**: All campaign data queries use parameterised queries through the data access layer.
+- **Section 1.4 — Input Validation**: All campaign submission fields are validated and sanitised at the system boundary.
+- **Section 1.5 — Authentication & Authorisation**: Every campaign endpoint is authenticated and authorised. Role-based access controls enforce who can submit, review, approve, and manage campaigns.
+- **Section 1.7 — Logging & Auditability**: Every campaign state mutation is logged with timestamp, actor identity, action, and affected resource.
+- **Section 3.4 — Code Review & Approval**: Changes to campaign flows affecting security surfaces require a second security reviewer.
+- **Section 4.2 — Test Coverage**: Campaign business logic requires 90% unit test coverage. Campaign API endpoints require 100% integration test coverage of documented contracts.
+- **Section 5 — API & Interface Contracts**: Campaign APIs are versioned, backward-compatible within a version, and use the standard error response format.
+
+### From [Architecture](L3-001)
+
+- Campaign service boundaries, data model, and inter-service communication patterns as defined in the system architecture.
+
+### From [Audit](L3-006)
+
+- All campaign state transitions, review decisions, milestone verifications, and fund release triggers are audit-logged per the immutable event stream architecture defined in L3-006.
+- Audit entries for campaign actions include the campaign ID, actor, previous state, new state, and rationale (where applicable).
+
+### From [Payments](L4-004)
+
+- Escrow creation, milestone disbursement, and refund execution are delegated to the payments domain. This spec defines the triggers; L4-004 defines the mechanics.
+
+---
+
+## 3. Campaign State Machine
+
+### 3.1 States
+
+| State | Description |
+| ----- | ----------- |
+| **Draft** | Creator is assembling the proposal. Not visible to reviewers or the public. |
+| **Submitted** | Creator has submitted the proposal for review. Immutable until review outcome. |
+| **Under Review** | A reviewer has been assigned and is evaluating the proposal. |
+| **Approved** | The proposal has passed review and is cleared to go live. |
+| **Rejected** | The proposal has been rejected with written rationale. |
+| **Live** | The campaign is publicly visible and accepting contributions. |
+| **Funded** | The campaign has reached its minimum funding target. Contributions continue until the deadline or maximum funding cap is reached. |
+| **Suspended** | Campaign temporarily frozen (e.g., creator KYC revoked). No new contributions accepted. Awaiting resolution. |
+| **Failed** | The campaign deadline has passed without reaching the minimum funding target. |
+| **Settlement** | Funds are being disbursed to the creator per the milestone plan. |
+| **Complete** | All milestones verified and all funds disbursed (or campaign otherwise finalised). |
+| **Cancelled** | Campaign cancelled by the creator or an administrator before completion. |
+
+### 3.2 Valid Transitions
+
+| From | To | Triggered By | Conditions |
+| ---- | -- | ------------ | ---------- |
+| Draft | Submitted | Creator | All required fields completed; creator has passed KYC (reference [KYC](L4-005)) |
+| Draft | Draft | Creator | Iterative editing; no constraints |
+| Submitted | Under Review | Reviewer | Reviewer claims campaign from review queue (FIFO) |
+| Under Review | Approved | Reviewer | Curation criteria met; written approval rationale recorded |
+| Under Review | Rejected | Reviewer | Written rejection rationale and resubmission guidance provided |
+| Rejected | Draft | Creator | Creator chooses to revise and resubmit |
+| Approved | Live | Creator or System | Creator sets launch date; system publishes at scheduled time |
+| Live | Funded | System | Minimum funding target reached; campaign remains live for additional contributions until deadline or maximum cap |
+| Live | Failed | System | Deadline reached without meeting minimum funding target |
+| Live | Cancelled | Creator or Admin | Creator requests cancellation; admin approves (if contributions exist, triggers refund — reference [Payments](L4-004)) |
+| Funded | Settlement | System or Admin | Deadline reached; first milestone verification triggered |
+| Settlement | Complete | System | All milestones verified and funds disbursed, OR final settlement action taken |
+| Live | Suspended | System or Admin | Creator KYC revoked or other compliance issue requiring investigation |
+| Funded | Suspended | System or Admin | Creator KYC revoked or other compliance issue requiring investigation |
+| Suspended | Live | Admin | Issue resolved (e.g., KYC re-verified); campaign resumes accepting contributions |
+| Suspended | Funded | Admin | Issue resolved; campaign was already funded before suspension |
+| Suspended | Cancelled | Admin | Issue not resolved within allowed window; contributions refunded via [Payments](L4-004) |
+| Settlement | Cancelled | Admin | Extraordinary circumstances; remaining funds refunded via [Payments](L4-004) |
+
+### 3.3 State Machine Rules
+
+- Every state transition is audit-logged per [Audit](L3-006) with: campaign ID, previous state, new state, actor, timestamp, and rationale.
+- No transition may skip states (e.g., Draft cannot go directly to Live).
+- Only one active transition may be in progress at a time per campaign.
+- The Cancelled state is terminal — no transitions out.
+- The Complete state is terminal — no transitions out.
+- When the maximum funding cap is reached, the campaign stops accepting new contributions. The campaign remains in Funded state until the deadline.
+
+---
+
+## 4. Project Submission Flow
+
+### 4.1 Submission Prerequisites
+
+- Creator must have a verified account (reference [Account](L4-001)).
+- Creator must have completed KYC verification (reference [KYC](L4-005)).
+
+### 4.2 Required Fields
+
+The submission form is a guided, multi-step flow. All fields are required unless marked optional.
+
+| Field Group | Fields | Notes |
+| ----------- | ------ | ----- |
+| **Mission Objectives** | Title, summary (≤280 chars), detailed description (rich text), Mars-mission alignment statement | How does this project contribute to getting humanity to Mars? |
+| **Team Credentials** | Team members (name, role, bio), relevant experience, advisory board (optional) | At least one team member required |
+| **Funding** | Minimum funding target (USD), maximum funding cap (USD), funding deadline, budget breakdown, campaign category | Budget breakdown must account for 100% of the minimum target. The platform uses USD. Maximum cap is the point at which the campaign stops accepting contributions. |
+| **Milestone Plan** | Milestones (title, description, target date, funding percentage, verification criteria) | At least two milestones required; funding percentages must sum to 100% |
+| **Risk Disclosures** | Key risks, mitigation strategies | At least one risk disclosure required |
+| **Media** | Hero image, additional images/video (optional) | Image specifications per [Brand](L2-001) |
+| **Stretch Goals** | Stretch goal tiers (optional): target amount, description, deliverables | Optional; if provided, must be above the minimum funding target and at or below the maximum funding cap |
+
+### 4.3 Draft Persistence
+
+- Drafts are auto-saved.
+- Creators may have multiple drafts simultaneously.
+- Drafts have no expiry.
+
+### 4.4 Campaign Categories
+
+Every campaign must be assigned exactly one primary category from the platform taxonomy.
+Creators may also add free-form tags for additional discoverability.
+
+| Category | Description |
+| -------- | ----------- |
+| Propulsion | Technologies that reduce travel time, cost, and risk of the Earth-to-Mars journey — chemical rockets, nuclear propulsion, orbital refuelling, transfer vehicles |
+| Entry, Descent & Landing | Systems for slowing down and landing safely on Mars — heat shields, retro-propulsion, precision landing for large payloads |
+| Power & Energy | Electricity generation and storage on Mars — solar arrays, nuclear fission reactors, energy storage, power distribution |
+| Habitats & Construction | Structures for living and working on Mars — pressurised modules, radiation shielding, regolith-based construction, lava tube utilisation |
+| Life Support & Crew Health | Systems that keep people alive — air recycling, water purification, waste management, medical capability, crew wellbeing |
+| Food & Water Production | Growing food and extracting water on Mars — controlled-environment agriculture, hydroponics, water ice extraction, bioreactors |
+| In-Situ Resource Utilisation | Using Martian materials to manufacture what the colony needs — oxygen and propellant production, metal extraction, 3D printing with local materials |
+| Radiation Protection | Shielding humans and electronics from cosmic rays and solar particles — shielding materials, underground habitats, biological countermeasures, early-warning systems |
+| Robotics & Automation | Robots that explore, build, and operate systems on Mars — autonomous rovers, construction robots, drilling systems, AI-driven operations |
+| Communications & Navigation | Connecting Mars to Earth and surface assets to each other — deep-space optical comms, relay satellites, surface mesh networks, positioning systems |
+
+This taxonomy is derived from NASA's Technology Taxonomy and adapted for a general donor audience per the "Accessibility Over Exclusivity" principle (L1-001).
+
+### 4.5 Submission Validation
+
+On submission, the system validates:
+
+- All required fields are present and non-empty.
+- Funding target is within platform bounds: minimum USD $1,000,000, maximum USD $1,000,000,000.
+- Milestone funding percentages sum to 100%.
+- Deadline is at least 1 week from submission date.
+- Deadline does not exceed 1 year from submission date.
+- All media meets format and size requirements.
+
+**AC-CAMP-001**: Given a creator has completed KYC verification and filled all required fields, when they submit a project proposal, then the proposal enters "Submitted" state and a confirmation notification is sent to the creator.
+
+**AC-CAMP-002**: Given a creator has not completed KYC verification, when they attempt to submit a project proposal, then submission is blocked and the creator is directed to the KYC verification flow.
+
+**AC-CAMP-003**: Given a creator submits a proposal with milestone funding percentages that do not sum to 100%, when validation runs, then submission is rejected with a clear error message identifying the discrepancy.
+
+---
+
+## 5. Review Pipeline
+
+### 5.1 Reviewer Role Assignment
+
+- Reviewers are users with the **Reviewer** role assigned via [Account](L4-001).
+- When a campaign enters Submitted state, it is added to a shared review queue ordered by submission time (FIFO).
+- A reviewer claims the next available campaign from the queue. No automatic assignment — reviewers pull work when ready.
+- A reviewer may recuse themselves, returning the campaign to the queue.
+- Admin users may manually reassign a campaign to a different reviewer.
+
+### 5.2 Curation Criteria
+
+Reviewers evaluate proposals against the following criteria:
+
+| Criterion | Description |
+| --------- | ----------- |
+| **Mars-Mission Alignment** | Does the project credibly contribute to Mars-enabling goals as defined in [Product Vision & Mission](L1-001)? |
+| **Feasibility** | Is the funding target realistic for the proposed deliverables? Is the timeline achievable? |
+| **Team Credibility** | Does the team have relevant experience or credentials? |
+| **Risk Transparency** | Are risks honestly disclosed with reasonable mitigation strategies? |
+| **Milestone Quality** | Are milestones specific, measurable, and verifiable? |
+| **Completeness** | Are all required fields substantively filled (not just placeholder text)? |
+
+### 5.3 Review Actions
+
+A reviewer may:
+
+- **Approve** — requires written approval notes.
+- **Reject** — requires written rejection rationale and resubmission guidance.
+- **Request Clarification** — sends questions back to the creator without changing state (campaign remains Under Review).
+
+### 5.4 Review SLA
+
+- Target time from Submitted to review outcome: 5 business days.
+- At 3 business days without a reviewer claiming the campaign, an alert is sent to all reviewers.
+- At 5 business days, the campaign is escalated to Admin for manual assignment or action.
+
+### 5.5 Audit Trail
+
+All review actions are audit-logged per [Audit](L3-006): reviewer identity, action taken, rationale provided, timestamp.
+
+**AC-CAMP-004**: Given a proposal is in "Submitted" state, when a reviewer claims it from the review queue, then the proposal transitions to "Under Review" and the creator is notified.
+
+**AC-CAMP-005**: Given a reviewer approves a proposal, when they submit their approval with written notes, then the proposal transitions to "Approved" and the creator is notified with the approval notes.
+
+---
+
+## 6. Approval and Rejection
+
+### 6.1 Approval
+
+- Approved campaigns are cleared to go live.
+- The creator is notified and may choose a launch date or launch immediately.
+- Approval rationale is stored and audit-logged.
+
+### 6.2 Rejection
+
+- Rejection requires:
+  - Written rationale explaining why the proposal does not meet curation criteria.
+  - Resubmission guidance: specific, actionable feedback on what the creator should change.
+- The creator is notified with the full rejection rationale and guidance.
+- The proposal returns to Draft state if the creator chooses to revise.
+
+### 6.3 Appeal Process
+
+- A creator may appeal a rejection by submitting an appeal request to the Admin role.
+- The appeal is reviewed by a different reviewer than the original.
+- Appeal outcomes: overturn (proposal moves to Approved) or uphold (rejection stands).
+- Appeal decisions are final.
+- All appeal actions are audit-logged.
+
+**AC-CAMP-006**: Given a reviewer rejects a proposal, when they submit the rejection with written rationale and resubmission guidance, then the proposal transitions to "Rejected" and the creator is notified with the rationale and guidance.
+
+**AC-CAMP-007**: Given a creator whose proposal was rejected, when they submit an appeal, then the appeal is assigned to a different reviewer and the creator is notified of the appeal status.
+
+**AC-CAMP-008**: Given a rejected proposal, when the creator chooses to revise and resubmit, then the proposal returns to "Draft" state with previous submission data preserved.
+
+---
+
+## 7. Live Campaign Management
+
+### 7.1 Public Campaign Page
+
+- Approved campaigns that have launched are publicly visible.
+- The campaign page displays: all submission fields (formatted per [Brand](L2-001)), funding progress (current amount vs. target), contributor count, time remaining, milestone plan, and stretch goals (if any).
+- The campaign page provides a contribution call-to-action that initiates the donor contribution flow (reference [Donor](L4-003) and [Payments](L4-004)).
+
+### 7.2 Funding Progress
+
+- Funding progress is updated in near-real-time as contributions are confirmed by [Payments](L4-004).
+- Progress is displayed as both absolute amount and percentage of minimum funding target.
+- Contributor count is displayed (individual donor identities are not shown on the public page unless the donor opts in — reference [Donor](L4-003)).
+
+### 7.3 Stretch Goals
+
+- If stretch goals are defined, they become visible on the campaign page once the minimum funding target is reached.
+- Each stretch goal tier activates when its funding threshold is reached.
+- Stretch goal activation is audit-logged.
+
+### 7.4 Deadline Enforcement
+
+- Every live campaign has a deadline.
+- The system automatically transitions the campaign at deadline:
+  - If minimum funding target met → **Funded** state.
+  - If minimum funding target not met → **Failed** state.
+
+#### Deadline Extensions
+
+- Creators may request a deadline extension while the campaign is Live.
+- Extensions require Admin approval.
+- Maximum single extension: 30 days.
+- Maximum total extensions per campaign: 90 days (cumulative).
+- Extension requests must include a written justification visible to contributors.
+- All contributors are notified when an extension is approved.
+- Extension approval is audit-logged per [Audit](L3-006).
+
+**AC-CAMP-019**: Given a live campaign, when a creator requests a deadline extension with written justification, and an Admin approves it, then the deadline is extended, all contributors are notified, and the extension is audit-logged.
+
+**AC-CAMP-020**: Given a live campaign, when a creator requests a deadline extension that would exceed the 90-day cumulative limit, then the extension request is rejected with an explanation.
+
+### 7.5 Campaign Updates
+
+- Creators may post updates to their live campaign (text and media).
+- Updates are visible on the campaign page and trigger notifications to contributors.
+- Creators may NOT modify the minimum funding target or maximum funding cap after going live.
+
+#### Milestone Change Requests
+
+- Creators may request changes to milestones after going live (e.g., adjusting dates, refining verification criteria, rebalancing funding percentages).
+- Milestone changes require Admin approval.
+- Milestone funding percentages must still sum to 100% after any change.
+- When a milestone change is approved, all contributors are notified with a summary of what changed.
+- The original milestone plan is preserved in the audit trail; changes are recorded as amendments.
+- Milestone change approval is audit-logged per [Audit](L3-006).
+
+**AC-CAMP-009**: Given a campaign is in "Approved" state, when the creator launches it, then the campaign transitions to "Live" and is publicly visible on the platform.
+
+**AC-CAMP-010**: Given a live campaign, when a contribution is confirmed by the payments system, then the funding progress is updated in near-real-time on the campaign page.
+
+**AC-CAMP-011**: Given a live campaign, when the minimum funding target is reached, then the campaign transitions to "Funded" state and remains open for contributions until the deadline or maximum funding cap is reached.
+
+**AC-CAMP-012**: Given a live campaign, when the deadline is reached and the minimum funding target has not been met, then the campaign transitions to "Failed" state and refunds are triggered via the payments system.
+
+**AC-CAMP-021**: Given a live or funded campaign, when a creator requests a milestone change, and an Admin approves it, then the milestone plan is updated, all contributors are notified with a summary of changes, and the original plan is preserved in the audit trail.
+
+**AC-CAMP-022**: Given a funded campaign, when a contribution would exceed the maximum funding cap, then the contribution is rejected and the donor is informed the campaign has reached its cap.
+
+---
+
+## 8. Milestone Definition and Verification
+
+### 8.1 Milestone Structure
+
+Each milestone includes:
+
+- Title and description.
+- Target completion date.
+- Funding percentage (portion of total funds released upon verification).
+- Verification criteria: specific, measurable conditions that must be met.
+
+### 8.2 Evidence Submission
+
+- When a creator believes a milestone is complete, they submit evidence (documents, images, links, reports) through the platform.
+- Evidence submissions are timestamped and immutable once submitted.
+
+### 8.3 Administrator Verification
+
+- An Admin reviews the submitted evidence against the milestone's verification criteria.
+- Verification outcomes:
+  - **Verified** — milestone criteria met. Triggers fund release for this milestone's funding percentage via [Payments](L4-004).
+  - **Returned** — evidence insufficient. Creator is notified with specific feedback and may resubmit.
+- All verification actions are audit-logged per [Audit](L3-006).
+
+### 8.4 Staged Fund Release
+
+- Funds are released per milestone, not in a lump sum.
+- Each milestone verification triggers a disbursement request to [Payments](L4-004) for the milestone's funding percentage of total collected funds.
+- No funds are released until the first milestone is verified.
+- The final milestone release settles the remaining escrowed balance.
+
+**AC-CAMP-013**: Given a campaign in "Settlement" state, when a creator submits evidence for a milestone, then the evidence is recorded and an Admin is notified for verification.
+
+**AC-CAMP-014**: Given an Admin reviews milestone evidence and verifies it, when they confirm verification, then the milestone is marked as verified and a disbursement for that milestone's funding percentage is triggered via the payments system.
+
+**AC-CAMP-015**: Given an Admin reviews milestone evidence and finds it insufficient, when they return it, then the creator is notified with specific feedback and may resubmit evidence.
+
+---
+
+## 9. Campaign Completion
+
+### 9.1 Successful Completion
+
+A campaign is complete when:
+
+- All milestones have been verified, AND
+- All funds have been disbursed via [Payments](L4-004).
+
+The system transitions the campaign to **Complete** state.
+
+### 9.2 Settlement Workflow
+
+1. Campaign reaches deadline in Funded state → transitions to Settlement.
+1. Creator submits evidence for each milestone sequentially.
+1. Admin verifies each milestone.
+1. Upon verification, disbursement is triggered for that milestone's portion.
+1. After final milestone verification and disbursement, campaign transitions to Complete.
+
+**AC-CAMP-016**: Given all milestones are verified and all funds disbursed, when the final disbursement is confirmed, then the campaign transitions to "Complete" state and the creator is notified.
+
+---
+
+## 10. Campaign Failure
+
+### 10.1 Failure Conditions
+
+A campaign fails when:
+
+- The deadline is reached and the minimum funding target has not been met.
+
+The funding model is **flexible with a minimum threshold**: campaigns that meet their minimum target keep what they raise (up to the maximum cap). Campaigns that do not reach the minimum target are failed and all contributions are refunded.
+
+### 10.2 Failure Handling
+
+1. Campaign transitions to **Failed** state.
+1. System triggers a refund for all contributions via [Payments](L4-004).
+1. Creator is notified that the campaign has failed.
+1. Contributors are notified that their contributions will be refunded.
+1. Failed campaigns remain visible on the platform (marked as failed) for transparency.
+
+### 10.3 Cancellation
+
+- A creator may cancel a Live campaign. If contributions exist, the Admin must approve the cancellation.
+- Upon cancellation, all contributions are refunded via [Payments](L4-004).
+- Cancellation during Settlement: Admin-only, remaining undisbursed funds are refunded.
+
+**AC-CAMP-017**: Given a live campaign, when the deadline passes without the minimum funding target being met, then the campaign transitions to "Failed" and refunds are triggered for all contributions.
+
+**AC-CAMP-018**: Given a creator requests cancellation of a live campaign with existing contributions, when an Admin approves the cancellation, then the campaign transitions to "Cancelled" and all contributions are refunded.
+
+---
+
+## 11. Interface Contracts
+
+### 11.1 Campaign ↔ Payments ([Payments](L4-004))
+
+| Event | Campaign Publishes | Payments Responds |
+| ----- | ------------------ | ----------------- |
+| Campaign goes Live | `CampaignLive` — campaign ID, minimum funding target, maximum funding cap, deadline | Payments creates escrow account for campaign |
+| Contribution received | — | Payments notifies campaign of confirmed contribution amount |
+| Funding target reached | `FundingTargetReached` — campaign ID | Payments acknowledges; no action until settlement |
+| Campaign funded at deadline | `CampaignFunded` — campaign ID, total collected | Payments holds funds in escrow pending milestone verification |
+| Milestone verified | `MilestoneVerified` — campaign ID, milestone ID, disbursement amount | Payments executes disbursement to creator |
+| Campaign failed | `CampaignFailed` — campaign ID | Payments executes refunds to all contributors |
+| Campaign suspended | `CampaignSuspended` — campaign ID, reason | Payments stops accepting new contributions for this campaign |
+| Campaign resumed | `CampaignResumed` — campaign ID | Payments resumes accepting contributions (if below cap and before deadline) |
+| Campaign cancelled | `CampaignCancelled` — campaign ID | Payments executes refunds for any existing contributions |
+| All milestones complete | `CampaignComplete` — campaign ID | Payments confirms all funds settled; closes escrow |
+
+Both specs must define these events.
+The event schema and transport mechanism are defined in [Architecture](L3-001).
+
+### 11.2 Campaign ↔ Donor ([Donor](L4-003))
+
+| Direction | Data Provided |
+| --------- | ------------- |
+| Campaign → Donor | Campaign metadata for discovery: title, summary, category, funding progress, deadline, status, hero image, Mars-mission alignment tags |
+| Donor → Campaign | Contribution data: contributor count, total contributed (aggregated), individual contribution events (via [Payments](L4-004)) |
+
+- The campaign service provides read-only campaign data to the donor discovery and search systems.
+- Contribution data flows through [Payments](L4-004), not directly from donor to campaign.
+
+### 11.3 Campaign ↔ Account ([Account](L4-001))
+
+| Role | Campaign Permissions |
+| ---- | -------------------- |
+| **Creator** | Create drafts, edit drafts, submit proposals, launch approved campaigns, post updates, submit milestone evidence, request cancellation, request deadline extensions, request milestone changes |
+| **Reviewer** | View and claim submitted proposals from review queue, approve/reject proposals, request clarification, recuse from review |
+| **Admin** | Reassign reviewers, approve cancellations, verify milestones, handle appeals, approve/reject deadline extensions, approve/reject milestone changes, manage suspended campaigns (restore or cancel) |
+| **Backer** (Donor) | View live campaigns, contribute (via [Payments](L4-004)), view updates and milestone progress |
+
+Role definitions and assignment are governed by [Account](L4-001).
+Campaign enforces permissions based on the authenticated user's role.
+
+### 11.4 Campaign ↔ KYC ([KYC](L4-005))
+
+- Campaign submission requires the creator to have a verified KYC status.
+- Campaign checks KYC verification status at submission time via the KYC domain interface.
+- If a creator's KYC status is revoked while a campaign is **Live**: the campaign is suspended (no new contributions accepted), the creator and Admin are notified, and the Admin determines next steps (cancel with refunds, or allow the creator to re-verify within 14 days). If re-verification is not completed within 14 days, the campaign is cancelled and all contributions are refunded via [Payments](L4-004).
+- If a creator's KYC status is revoked during **Settlement**: disbursements are paused, Admin is notified, and no further milestone payments are released until re-verification is complete. Funds already disbursed are not clawed back.
+
+**AC-CAMP-023**: Given a live campaign, when the creator's KYC status is revoked, then the campaign transitions to "Suspended", no new contributions are accepted, and the creator and Admin are notified.
+
+**AC-CAMP-024**: Given a suspended campaign, when the creator completes KYC re-verification within 14 days, then the Admin may restore the campaign to its previous state (Live or Funded).
+
+**AC-CAMP-025**: Given a suspended campaign, when 14 days elapse without KYC re-verification, then the campaign is cancelled and all contributions are refunded via the payments system.
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| ---- | ------- | ------ | ------- |
+| March 2026 | 0.1 | — | Initial stub. Campaign state machine, submission flow, review pipeline, approval/rejection, live management, milestones, completion, failure, interface contracts with Payments, Donor, Account, and KYC. |
+| March 2026 | 0.2 | — | Resolved all open questions. Funding: USD, min $1M, max $1B. Flexible funding model (min threshold + max cap). Duration: 1 week–1 year. Pull-based reviewer queue (FIFO), 5-day SLA. Deadline extensions (30-day max, 90-day cumulative). Milestone change requests with Admin approval and contributor notification. KYC revocation handling (14-day re-verification window). Unlimited simultaneous campaigns. 10-category taxonomy based on NASA Technology Taxonomy. |

--- a/specs/domain/donor.md
+++ b/specs/domain/donor.md
@@ -1,0 +1,435 @@
+# Donor
+
+> **Spec ID**: L4-003
+> **Version**: 0.3
+> **Status**: Approved
+> **Rate of Change**: Per feature / per release
+> **Depends On**: L1-001 (Product Vision & Mission), L2-001 (standards/brand.md), L3-005 (tech/frontend.md), L4-001 (domain/account.md), L4-002 (domain/campaign.md), L4-004 (domain/payments.md)
+> **Depended On By**: —
+
+---
+
+## 1. Purpose
+
+> **Local demo scope**: Campaign discovery, search, contribution flow (up to payment handoff), and contribution history are **real** — they are implemented in the local demo. The recommendation engine, re-engagement automation, tax receipt generation, and social sharing are theatre. The local demo focuses on browse, contribute, and view history.
+
+This spec defines the complete donor-side bounded context for Mars Mission Fund: how backers discover campaigns, make contributions, and maintain an ongoing relationship with the missions they support.
+
+It implements the "Accessibility Over Exclusivity" principle from the [Product Vision & Mission](L1-001) — the platform must make it easy for anyone to participate in funding Mars-enabling projects, regardless of contribution size or technical sophistication.
+
+### In Scope
+
+- Campaign discovery and search.
+- Recommendation engine.
+- Curated collections and category browsing.
+- Contribution flow (up to payment handoff).
+- Ongoing donor relationship management (milestone updates, impact reports, notifications).
+- Contribution history and personal dashboard.
+- Cumulative impact reporting.
+- Repeat engagement and re-engagement patterns.
+- Tax receipt presentation (donor-facing).
+- Social sharing (campaign link only, post-contribution).
+
+### Out of Scope
+
+- Payment processing, escrow, and financial settlement — governed by [Payments](L4-004).
+- Campaign creation, review pipeline, and lifecycle management — governed by [Campaign](L4-002).
+- Account registration, authentication, profile management, and session handling — governed by [Account](L4-001).
+- KYC verification — governed by [KYC](L4-005).
+- Audit logging implementation — governed by [Audit](L3-006).
+  This spec defines what donor events are audit-logged; the audit spec defines how.
+
+---
+
+## 2. Inherited Constraints
+
+### From [Engineering Standard](L2-002)
+
+| Section | Constraint | Application to Donor Context |
+| ------- | ---------- | ---------------------------- |
+| 1.2 Data Access | Parameterised queries only | All search queries, contribution lookups, and history retrieval must use the data access layer. No raw SQL. |
+| 1.4 Input Validation | All external input validated at boundary | Search terms, filter parameters, contribution amounts, and recommendation feedback must be validated and sanitised. |
+| 1.5 Authentication & Authorisation | Every endpoint authenticated | Donor endpoints that mutate state (contributions, preferences, dismissals) require an authenticated session. Campaign discovery and search (Section 3) are accessible to anonymous users; personalisation features (recommendations, search history) require authentication. |
+| 1.7 Logging & Auditability | Every state mutation logged | Contributions initiated, cancelled, and completed are state mutations. Preference changes and notification opt-outs must also be logged. |
+| 4.2 Test Coverage | 90% unit, 100% integration for API contracts | All search, contribution, and history endpoints require full contract coverage. |
+| 5.1–5.3 API Contracts | Versioned, backward-compatible, consistent errors | Donor APIs follow the standard versioning, compatibility, and error response rules. |
+| 6.1 Structured Logging | JSON logs with correlation ID | All donor service log entries include correlation ID for end-to-end tracing through search → contribution → payment flows. |
+
+### From [Brand Application Standard](L2-001)
+
+| Section | Constraint | Application to Donor Context |
+| ------- | ---------- | ---------------------------- |
+| 2.1–2.6 Semantic Tokens | Components consume Tier 2 only | All donor UI (search results, campaign cards, contribution forms, dashboards) must use semantic tokens exclusively. |
+| 3.2 Cards | Card specification | Campaign discovery cards follow the card component spec. |
+| 3.3 Progress Bars | Progress bar specification | Funding progress on campaign cards and detail views follows the progress bar spec. |
+| 4.2 Copy Patterns | Voice-in-product | All donor-facing copy (search empty states, contribution confirmations, milestone notifications) follows the copy patterns defined in L2-001 Section 4.2. |
+| 5.1–5.4 Accessibility | WCAG 2.1 AA minimum | Search interfaces, contribution flows, and dashboards must meet all accessibility requirements including contrast, motion, focus, and screen reader support. |
+
+### From [Frontend Standards](L3-005)
+
+- Component library standards, performance budgets, and responsive breakpoints apply to all donor UI.
+- Accessibility requirements (WCAG 2.1 AA minimum) as detailed in L3-005.
+
+---
+
+## 3. Discovery and Search
+
+### 3.1 Search Interface
+
+The donor search interface is the primary mechanism for campaign discovery.
+It is accessible to both anonymous and authenticated users.
+It provides full-text search across campaign titles, descriptions, creator names, and mission codes.
+Anonymous users see search results and campaign details but do not receive personalised recommendations or persistent search history.
+
+**Search features**:
+
+- Full-text search with relevance ranking.
+- Auto-complete suggestions as the donor types (debounced input, results within performance budget defined by [Frontend Standards](L3-005)).
+- Search result highlighting of matched terms.
+- Persistent search history per donor (opt-out available via notification preferences in [Account](L4-001)).
+
+### 3.2 Filters
+
+Donors can narrow search results and browse views using the following filter dimensions:
+
+| Filter | Type | Values |
+| ------ | ---- | ------ |
+| Category | Multi-select | Categories defined in [Campaign](L4-002) taxonomy |
+| Funding status | Single-select | Active, Fully Funded, Ending Soon, New |
+| Deadline | Range | Date range picker (from–to) |
+| Contribution amount range | Range | Min–max slider or manual entry |
+| Sort order | Single-select | Relevance, Newest, Ending Soon, Most Funded, Least Funded |
+
+Filters are composable — multiple filters apply simultaneously with AND logic.
+Filter state is preserved in the URL for shareability and back-button behaviour.
+
+### 3.3 Search Results
+
+Search results display campaign cards following the card component spec from [Brand Application Standard](L2-001), Section 3.2.
+Each card shows at minimum:
+
+- Campaign title.
+- Creator name.
+- Category badge.
+- Funding progress bar (L2-001, Section 3.3).
+- Percentage funded and amount raised.
+- Days remaining (or "Funded" badge if complete).
+- Campaign hero image (thumbnail).
+
+Pagination or infinite scroll behaviour is defined by [Frontend Standards](L3-005).
+
+**AC-DONOR-001**: Given a donor enters a search term, when results are returned, then results are ranked by relevance and displayed within the performance budget defined by [Frontend Standards](L3-005).
+
+**AC-DONOR-002**: Given a donor applies a category filter, when the filter is active, then only campaigns in the selected category are displayed and the active filter is visually indicated.
+
+**AC-DONOR-003**: Given a donor applies a "Funding status: Ending Soon" filter, when results are displayed, then only campaigns with deadlines within 7 days are shown, sorted by nearest deadline first.
+
+**AC-DONOR-020**: Given an unauthenticated user visits the search interface, when they search for campaigns, then results are displayed without personalised recommendations or persistent search history, and a prompt to sign in for personalised features is shown.
+
+---
+
+## 4. Recommendation Engine
+
+### 4.1 Approach
+
+The recommendation engine surfaces campaigns a donor is likely to support, based on their contribution history, browsing behaviour, and stated preferences.
+
+**Algorithm**: Hybrid approach.
+Content-based filtering is used as the primary engine and handles cold-start (fewer than 3 contributions) by matching stated category preferences and browsing behaviour.
+Collaborative filtering supplements content-based results once the donor has 3 or more contributions, surfacing campaigns backed by donors with similar contribution patterns.
+
+### 4.2 Recommendation Inputs
+
+| Input | Source | Description |
+| ----- | ------ | ----------- |
+| Contribution history | This spec (Section 7) | Categories, amounts, and campaigns previously backed |
+| Browsing behaviour | Analytics events | Campaigns viewed, time spent, search terms used |
+| Stated preferences | [Account](L4-001) preferences | Category interests, notification preferences |
+| Campaign metadata | [Campaign](L4-002) | Category, funding status, creator, milestones, similar campaigns |
+
+### 4.3 Recommendation Outputs
+
+- Personalised "Recommended for You" section on the donor dashboard.
+- "Similar Missions" section on individual campaign pages.
+- Re-engagement recommendations (see Section 9).
+
+### 4.4 Constraints
+
+- Recommendations must never surface campaigns the donor has already backed (unless re-engagement for milestone updates).
+- Recommendations must not create filter bubbles — at least 20% of recommendations must come from categories the donor has not previously explored.
+- Recommendation explanations must be provided ("Because you backed Mission X" or "Popular in [Category]").
+- Donors can dismiss recommendations; dismissed campaigns do not reappear.
+
+**AC-DONOR-004**: Given a donor has backed at least 3 campaigns, when they view their dashboard, then personalised recommendations are displayed with explanations for each recommendation.
+
+**AC-DONOR-005**: Given a donor dismisses a recommended campaign, when they next view recommendations, then the dismissed campaign does not appear.
+
+---
+
+## 5. Curated Collections
+
+### 5.1 Editorial Collections
+
+Curated collections are editorially managed groupings of campaigns, created by platform staff.
+
+- "Staff Picks" — a rotating editorial selection.
+- Thematic collections (e.g., "Habitat Projects", "Propulsion Research", "Life Support Systems").
+- Seasonal or event-driven collections (e.g., "Mars Window 2028 Countdown").
+
+Collection management (creation, ordering, publishing) is an administrative function.
+The donor spec governs the donor-facing presentation and browsing experience.
+
+### 5.2 Category Browsing
+
+Donors can browse campaigns by category taxonomy as defined in [Campaign](L4-002).
+Category pages display:
+
+- Category description and hero image.
+- Aggregate stats (total campaigns, total raised, active campaigns).
+- Campaign cards sorted by default relevance, with filter and sort controls.
+
+**AC-DONOR-006**: Given a donor navigates to a curated collection, when the collection page loads, then campaigns are displayed in the editorial order with collection title, description, and hero image.
+
+**AC-DONOR-007**: Given a donor browses a category page, when the page loads, then aggregate category stats and campaign cards are displayed with filter and sort controls.
+
+---
+
+## 6. Contribution Flow
+
+### 6.1 Flow Overview
+
+The contribution flow is the donor's path from campaign selection to completed contribution.
+This spec owns the donor-facing experience up to payment handoff; [Payments](L4-004) owns all payment processing.
+
+```text
+Campaign Page → "Back This Mission" CTA → Contribution Amount Selection
+→ Contribution Summary → Payment Handoff (→ L4-004) → Confirmation
+```
+
+### 6.2 Amount Selection
+
+- Predefined contribution tiers (if defined by campaign creator — see [Campaign](L4-002) interface contract).
+- Custom amount entry with minimum and maximum validation.
+  Minimum contribution amount is **$5 USD** (platform-level configuration).
+  For the initial release, all contributions are in USD only.
+  Maximum is governed by regulatory limits (if applicable) and campaign caps.
+- Amount displayed with currency formatting per donor locale.
+
+### 6.3 Contribution Summary
+
+Before payment handoff, the donor sees a summary:
+
+- Campaign title and mission code.
+- Contribution amount (formatted).
+- Any contribution tier benefits (if applicable).
+- Clear statement that this is a contribution, not an investment (per [Brand Application Standard](L2-001) Section 4.3 — forbidden language patterns).
+
+### 6.4 Payment Handoff
+
+At the point of payment, control transfers to [Payments](L4-004).
+This spec provides:
+
+- Donor identity (from authenticated session).
+- Campaign identifier.
+- Contribution amount.
+- Contribution metadata (tier selection, if applicable).
+
+[Payments](L4-004) returns:
+
+- Payment confirmation or failure status.
+- Transaction reference.
+- Receipt data.
+
+### 6.5 Confirmation
+
+On successful payment, the donor sees a confirmation screen following the financial confirmation copy patterns from [Brand Application Standard](L2-001), Section 4.2:
+
+- Precise amount and mission reference.
+- Transaction reference number.
+- Expected next steps (milestone updates, impact reports).
+- Option to share the campaign via social sharing (see Section 6.6).
+
+On payment failure, the donor sees an error following the error state copy patterns from [Brand Application Standard](L2-001), Section 4.2.
+
+**AC-DONOR-008**: Given a donor selects "Back This Mission" on a campaign page, when they enter a valid contribution amount, then a contribution summary is displayed with campaign title, amount, and clear "contribution not investment" language.
+
+**AC-DONOR-009**: Given a donor confirms their contribution, when payment is successfully processed by [Payments](L4-004), then a confirmation screen is displayed with the precise amount, mission code, and transaction reference.
+
+**AC-DONOR-010**: Given a donor confirms their contribution, when payment fails, then an error message is displayed following the error copy patterns from [Brand Application Standard](L2-001) with a clear retry path.
+
+### 6.6 Social Sharing
+
+After a successful contribution, donors can share the campaign (not the contribution amount) via:
+
+- **X / Twitter**: Pre-populated post with campaign title and link.
+- **Facebook**: Share dialog with campaign title, hero image, and link.
+- **LinkedIn**: Share dialog with campaign title and link.
+- **Copy to clipboard**: Plain campaign URL for pasting anywhere.
+
+Shared content includes only the campaign link and title — the donor's contribution amount is never included in shared content for privacy reasons.
+All shared links use Open Graph meta tags defined by the campaign page.
+
+**AC-DONOR-019**: Given a donor completes a contribution, when they select a social sharing option, then the shared content includes the campaign title and link but does not include the contribution amount.
+
+---
+
+## 7. Contribution History
+
+### 7.1 Personal Dashboard
+
+Every authenticated donor has a personal contribution dashboard displaying:
+
+- All contributions (past and pending).
+- For each contribution: campaign title, mission code, amount, date, status (confirmed, pending, refunded).
+- Running total of all contributions.
+- Filtering and sorting: by date, amount, status, category.
+
+### 7.2 Contribution Statuses
+
+| Status | Description |
+| ------ | ----------- |
+| Pending | Payment initiated, awaiting confirmation from [Payments](L4-004) |
+| Confirmed | Payment confirmed, funds in escrow |
+| In Progress | Campaign active, milestones being delivered |
+| Completed | Campaign fully funded and all milestones delivered |
+| Refunded | Contribution refunded (campaign failed or cancelled) |
+
+Status transitions are driven by events from [Payments](L4-004) and [Campaign](L4-002).
+
+### 7.3 Tax Receipts
+
+Tax receipts are generated for confirmed contributions.
+Financial data (amounts, dates, transaction references) comes from [Payments](L4-004).
+This spec owns the donor-facing presentation:
+
+- Downloadable PDF receipt.
+- Receipt includes: donor name, contribution amount, date, campaign title, mission code, platform legal entity details.
+- Annual summary receipt (aggregating all contributions in a tax year).
+
+**Supported jurisdictions at launch**: Australia (AU), United States (US), European Union (EU), and United Kingdom (UK).
+Each jurisdiction's receipt template must satisfy local tax authority requirements for charitable contribution documentation.
+Jurisdiction is determined by the donor's registered address in [Account](L4-001).
+
+**AC-DONOR-011**: Given a donor navigates to their contribution history, when the page loads, then all contributions are displayed with campaign title, amount, date, and status.
+
+**AC-DONOR-012**: Given a donor has a confirmed contribution, when they request a tax receipt, then a downloadable PDF receipt is generated with all required fields.
+
+**AC-DONOR-013**: Given a donor requests an annual summary, when the summary is generated, then it aggregates all confirmed contributions for the selected tax year with total amount.
+
+---
+
+## 8. Impact Reporting
+
+### 8.1 Cumulative Impact Dashboard
+
+The impact dashboard provides a high-level view of the donor's total contribution footprint:
+
+- Total amount contributed (lifetime).
+- Number of campaigns backed.
+- Number of milestones achieved (across all backed campaigns).
+- Number of campaigns fully completed.
+- Contribution timeline visualisation (contributions over time).
+
+### 8.2 Per-Campaign Impact
+
+For each backed campaign, the donor can view:
+
+- Campaign progress (funding percentage, milestone status).
+- Milestone timeline with completion dates.
+- Creator updates and impact reports (content provided by campaign creator via [Campaign](L4-002)).
+- Fund disbursement events (milestone-triggered releases, sourced from [Payments](L4-004)).
+
+### 8.3 Milestone Notifications
+
+When a campaign the donor has backed reaches a milestone:
+
+- In-app notification.
+- Email notification (if opted in via [Account](L4-001) notification preferences).
+- Push notification (if opted in and supported).
+
+Notification content follows the voice-in-product patterns from [Brand Application Standard](L2-001).
+
+**AC-DONOR-014**: Given a donor navigates to their impact dashboard, when the page loads, then cumulative stats (total contributed, campaigns backed, milestones achieved, campaigns completed) are displayed.
+
+**AC-DONOR-015**: Given a campaign the donor has backed achieves a milestone, when the milestone is verified, then the donor receives an in-app notification and an email notification (if opted in).
+
+**AC-DONOR-016**: Given a donor views a backed campaign's impact page, when the page loads, then the milestone timeline, creator updates, and disbursement events are displayed.
+
+---
+
+## 9. Repeat Engagement
+
+### 9.1 Re-engagement Patterns
+
+The platform actively encourages repeat contributions through:
+
+- **Related campaign recommendations**: After a contribution is confirmed, surface similar campaigns (see Section 4).
+- **Milestone-triggered recommendations**: When a backed campaign reaches a milestone, recommend other campaigns in the same category.
+- **Contribution anniversaries**: On the anniversary of a donor's first contribution, send a personalised impact summary and recommend new campaigns.
+- **Campaign completion follow-up**: When a backed campaign completes, celebrate the achievement and recommend new campaigns.
+
+### 9.2 Re-engagement Constraints
+
+- Re-engagement communications respect notification preferences from [Account](L4-001).
+- Frequency caps apply — no donor receives more than **1 re-engagement notification per week**.
+- All re-engagement messaging follows the voice-in-product patterns from [Brand Application Standard](L2-001).
+  Re-engagement must never read as spam or pressure.
+
+**AC-DONOR-017**: Given a donor's backed campaign completes successfully, when the completion event is received, then the donor receives a celebration notification with impact summary and related campaign recommendations.
+
+**AC-DONOR-018**: Given a donor has reached the weekly re-engagement notification cap, when a new re-engagement trigger fires, then the notification is suppressed until the next notification window.
+
+---
+
+## 10. Interface Contracts
+
+### 10.1 Campaign (L4-002) → Donor (L4-003)
+
+This spec **consumes** campaign data for discovery and display.
+
+| Data | Direction | Description |
+| ---- | --------- | ----------- |
+| Campaign listing data | Campaign → Donor | Title, description, category, creator, hero image, funding target, amount raised, deadline, status, mission code |
+| Campaign detail data | Campaign → Donor | Full campaign description, milestones, stretch goals, creator updates, media |
+| Category taxonomy | Campaign → Donor | Category hierarchy for browsing and filtering |
+| Milestone events | Campaign → Donor | Milestone verified, milestone failed — triggers donor notifications |
+| Campaign completion event | Campaign → Donor | Campaign funded / failed — triggers donor dashboard updates and re-engagement |
+
+This spec **provides** contribution data back to Campaign:
+
+| Data | Direction | Description |
+| ---- | --------- | ----------- |
+| Contribution count | Donor → Campaign | Number of backers (for campaign display) |
+| Contribution initiated event | Donor → Campaign | Signals a new contribution (campaign may update backer count) |
+
+### 10.2 Payments (L4-004) → Donor (L4-003)
+
+This spec **hands off** payment processing and **receives** confirmation.
+
+| Data | Direction | Description |
+| ---- | --------- | ----------- |
+| Payment request | Donor → Payments | Donor ID, campaign ID, amount, contribution metadata |
+| Payment confirmation | Payments → Donor | Success/failure status, transaction reference, receipt data |
+| Refund event | Payments → Donor | Refund processed — triggers status update in contribution history |
+| Disbursement event | Payments → Donor | Milestone-based fund release — displayed in per-campaign impact view |
+| Tax receipt data | Payments → Donor | Financial data for receipt generation (amounts, dates, transaction references) |
+
+### 10.3 Account (L4-001) → Donor (L4-003)
+
+This spec **consumes** backer identity and preferences.
+
+| Data | Direction | Description |
+| ---- | --------- | ----------- |
+| Donor identity | Account → Donor | Authenticated user ID, display name |
+| Notification preferences | Account → Donor | Email opt-in/out, push notification preferences, frequency caps |
+| Category preferences | Account → Donor | Stated category interests for recommendation engine input |
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| ---- | ------- | ------ | ------- |
+| March 2026 | 0.3 | — | Added social sharing to In Scope list, clarified multi-currency minimum contribution equivalent, added AC-DONOR-020 for anonymous browsing. |
+| March 2026 | 0.2 | — | Resolved all 7 open questions: hybrid recommendation algorithm, 20% diversity floor, $5 USD minimum contribution, 1 re-engagement notification per week cap, anonymous browse access, AU/US/EU/UK tax receipt jurisdictions, social sharing (campaign link only to X/Twitter/Facebook/LinkedIn/clipboard). Added Section 6.6 (Social Sharing) and AC-DONOR-019. |
+| March 2026 | 0.1 | — | Initial stub. Discovery and search, recommendation engine, curated collections, contribution flow, contribution history, impact reporting, repeat engagement, interface contracts with Campaign, Payments, and Account. |

--- a/specs/domain/kyc.md
+++ b/specs/domain/kyc.md
@@ -1,0 +1,559 @@
+# KYC — Identity Verification
+
+> **Spec ID**: L4-005
+> **Version**: 0.3
+> **Status**: Approved
+> **Rate of Change**: Per feature / per release
+> **Depends On**: L2-002 (Engineering Standard), L3-002 (Security), L3-004 (Data Management), L3-006 (Audit Logging & Transparency)
+> **Depended On By**: L4-001 (Account), L4-002 (Campaign), L4-004 (Payments)
+
+---
+
+## 1. Purpose
+
+> **Local demo scope**: The KYC verification status lifecycle and its gating effect on Creator role features are **real** — the local demo enforces KYC status checks. The actual KYC provider is **stubbed** (no real document verification). Sanctions screening, manual review workflows, document storage encryption, re-verification triggers, and jurisdictional requirements are theatre. The local demo auto-approves KYC submissions.
+
+This spec governs identity verification for Mars Mission Fund: KYC document upload, automated verification checks, sanctions screening, manual review workflows, verification status lifecycle, re-verification triggers, jurisdictional requirements, and data retention rules specific to identity documents.
+
+**What this spec governs**:
+
+- Document upload and validation workflow.
+- Automated identity verification via third-party KYC provider.
+- Video liveness verification as part of identity checks.
+- Sanctions screening (OFAC, EU, UN, Australian DFAT sanctions lists).
+- Manual review workflow for edge cases and failed automated checks.
+- Verification status lifecycle and state transitions.
+- Re-verification triggers (document expiry, regulatory change, suspicious activity).
+- Jurisdictional document requirements by country.
+- Identity document storage, encryption, retention, and deletion.
+
+**What this spec does NOT cover**:
+
+- Account registration, profile management, and role assignment mechanics — see [Account](L4-001).
+  This spec defines the KYC verification states that feed into account verification; [Account](L4-001) implements the user-facing integration.
+- Payment processing, escrow, and disbursement — see [Payments](L4-004).
+  This spec defines KYC status as a gate for disbursement eligibility; [Payments](L4-004) enforces that gate.
+- Campaign submission and review pipeline — see [Campaign](L4-002).
+  This spec defines KYC status as a gate for project submission eligibility; [Campaign](L4-002) enforces that gate.
+- Authentication, authorisation, and RBAC model — see [Security](L3-002).
+- Data classification scheme and general retention policies — see [Data Management](L3-004).
+  This spec references the Restricted classification for identity documents and defines KYC-specific retention.
+- Audit event schemas and immutability guarantees — see [Audit](L3-006).
+  This spec defines which KYC events are auditable; [Audit](L3-006) defines the logging mechanism.
+
+---
+
+## 2. Inherited Constraints
+
+### From [Engineering Standard](L2-002)
+
+| L2-002 Section | Constraint | How This Spec Applies It |
+| --- | --- | --- |
+| 1.1 (Encryption) | All sensitive data encrypted at rest (AES-256) and in transit (TLS 1.3) | KYC documents and verification results are classified Restricted per [Data Management](L3-004), Section 1.1 — encrypted at rest with AES-256 and additional key management controls |
+| 1.2 (Data Access) | Parameterised queries only; all access through data access layer | All KYC data queries go through the data access layer with classification-based access checks |
+| 1.4 (Input Validation) | All external input validated at system boundary; file uploads validated for type, size, and content; uploaded files served from separate domain | Document uploads validated for file type (magic bytes), size limits, and content scanning before acceptance |
+| 1.7 (Logging & Auditability) | Every state mutation logged; sensitive data never logged | All KYC status transitions, document uploads, verification results, and review decisions are logged as audit events; document content and PII are never logged |
+| 2.3 (What We Don't Build) | Identity verification infrastructure is integrated, not built | KYC provider is a third-party service, integrated via adapter |
+| 2.4 (Abstraction Requirement) | External dependencies accessed through internal interfaces | KYC provider accessed through an abstraction layer; no vendor SDK referenced directly by application code |
+
+### From [Security](L3-002)
+
+| L3-002 Section | Constraint | How This Spec Applies It |
+| --- | --- | --- |
+| 4.2 (MFA) | MFA required for administrative operations | Manual review decisions and admin overrides on KYC status require MFA |
+| 5.1 (RBAC) | Five-role model with defined capabilities | KYC document submission available to authenticated users; manual review restricted to Administrator and Super Administrator roles |
+| 5.2 (Role Assignment) | Creator role granted after KYC verification | This spec defines the verification lifecycle that determines when Creator role eligibility is triggered |
+| 8.2 (GDPR) | DPIA required for KYC processing | Data Protection Impact Assessment required before KYC processing goes live |
+| 8.3 (Australian Privacy Act) | APP 3 — collect only what is necessary | Only identity documents required for verification are collected; no extraneous personal data |
+
+### From [Data Management](L3-004)
+
+| L3-004 Section | Constraint | How This Spec Applies It |
+| --- | --- | --- |
+| 1.1 (Classification) | KYC identity documents classified as Restricted | All identity documents, sanctions screening results, and verification decision records stored with Restricted-level controls |
+| 2.1 (Retention) | KYC documents retained for duration of active account + 1 year active, 7 years archive after account closure | This spec implements KYC-specific retention per the schedule in [Data Management](L3-004) |
+| 4.5 (Right-to-Erasure) | Erasure workflow for data subject requests | KYC documents subject to AML/CTF retention override — identity documents retained for legal minimum even after erasure request; documented in Section 8.4 |
+| 5.1 (Access by Classification) | Restricted data requires MFA-verified access, all access logged and alerted | All access to KYC documents and verification records enforces MFA and is audit-logged |
+
+### From [Audit](L3-006)
+
+| L3-006 Section | Constraint | How This Spec Applies It |
+| --- | --- | --- |
+| 4.1 (Event Categories) | KYC events are a defined audit event category (`kyc`) | All KYC state transitions emit `kyc`-type audit events per the schema in [Audit](L3-006), Section 3 |
+| 6.1 (Retention) | KYC audit events retained 7 years after relationship end | KYC audit retention aligned with AML/CTF record-keeping obligations |
+| 9.1 (Anomaly Detection) | Suspicious activity patterns detected | Repeated verification failures, unusual document submission patterns, and sanctions screening flag patterns are routed to anomaly detection |
+
+---
+
+## 3. KYC Verification Flow
+
+### 3.1 Flow Overview
+
+```text
+[User initiates KYC] → [Document Upload] → [Video Liveness Capture] → [Input Validation]
+        │
+        ├── Validation fails → [Rejected — invalid document] → User notified, can retry
+        │
+        └── Validation passes → [Automated Verification (document + liveness)]
+                │
+                ├── Automated check passes → [Sanctions Screening]
+                │       │
+                │       ├── Sanctions clear → [Verified] → Account KYC status updated
+                │       │
+                │       └── Sanctions match → [Rejected — sanctions] → Admin notified, account flagged
+                │
+                ├── Liveness check fails → [Pending Resubmission] → User notified to retry liveness
+                │
+                └── Automated check fails or inconclusive → [Manual Review Queue]
+                        │
+                        ├── Reviewer approves → [Sanctions Screening] → (same as above)
+                        │
+                        ├── Reviewer requests resubmission → [Pending Resubmission] → User notified
+                        │
+                        └── Reviewer rejects → [Rejected — manual review] → User notified with rationale
+```
+
+### 3.2 Flow Steps
+
+1. **Initiation**: User navigates to KYC verification and selects document type appropriate for their jurisdiction (see Section 4.3).
+1. **Document Upload**: User uploads identity document image(s). Front and back required for documents with information on both sides.
+1. **Video Liveness Capture**: User completes a video liveness session via Veriff's SDK (embedded behind the abstraction layer).
+1. **Input Validation**: Uploaded files validated at the system boundary per [Engineering Standard](L2-002), Section 1.4:
+   - File type validation (magic bytes — accepted formats: JPEG, PNG, PDF).
+   - File size validation (maximum 20 MB per document).
+   - Content scanning for malware.
+   - Image quality check (resolution, readability — basic checks before sending to provider).
+1. **Automated Verification**: Document and video liveness capture submitted to Veriff via abstraction layer (see Section 5.1).
+1. **Sanctions Screening**: Identity checked against sanctions lists (see Section 5.2).
+1. **Manual Review** (if needed): Failed or inconclusive automated checks escalated to review queue (see Section 5.3).
+1. **Status Update**: Verification status updated; dependent systems notified via interface contracts (see Section 10).
+
+---
+
+## 4. Document Types and Acceptance
+
+### 4.1 Accepted Document Types
+
+| Document Type | Jurisdictions | Requirements |
+| --- | --- | --- |
+| Passport | All | Photo page; must be current (not expired) |
+| National Identity Card | Countries where government-issued national ID exists | Front and back; must be current |
+| Driver's Licence | Australia, United States, United Kingdom, EU member states | Front and back; must be current; photo required |
+
+Additional documents (e.g., residence permits, government-issued photo cards) may be added per jurisdiction as market scope expands.
+
+### 4.2 Document Validity Requirements
+
+- Documents must not be expired at the time of submission.
+- Documents must contain a clear, legible photo of the holder.
+- Documents must display the holder's full legal name, date of birth, and document number.
+- Documents must be original (not photocopies of photocopies) — the KYC provider's liveness and authenticity checks validate this.
+
+### 4.3 Jurisdictional Requirements
+
+Different jurisdictions may require different document types or additional documentation.
+The platform must support configurable document requirements per country.
+
+| Jurisdiction | Primary Accepted Documents | Additional Requirements |
+| --- | --- | --- |
+| Australia | Passport, Driver's Licence | — |
+| United States | Passport, Driver's Licence | — |
+| United Kingdom | Passport, Driver's Licence, National ID | — |
+| EU Member States | Passport, National ID, Driver's Licence | Document language support required |
+
+Jurisdictional configuration must be maintained as reference data, not hardcoded.
+
+---
+
+## 5. Verification Processes
+
+### 5.1 Automated Verification
+
+The platform integrates with Veriff for automated identity verification (per [Tech Stack](L3-008)).
+Per [Engineering Standard](L2-002), Section 2.3, identity verification infrastructure is integrated, not built.
+Per [Engineering Standard](L2-002), Section 2.4, the Veriff SDK is wrapped behind an abstraction layer.
+
+**Abstraction layer responsibilities**:
+
+- Translate internal document submission requests to the provider's API format.
+- Translate provider responses to internal verification result format.
+- Handle provider-specific error codes and map them to internal status values.
+- Support provider replacement without changing consuming code.
+
+**Automated verification checks** (performed by provider):
+
+- Document authenticity (forgery detection, tampering detection).
+- Document data extraction (OCR for name, date of birth, document number, expiry).
+- Facial comparison via video liveness check (required for all verifications).
+- Data consistency (extracted data matches user-provided profile data).
+
+**Verification result mapping**:
+
+| Provider Result | Internal Status | Next Step |
+| --- | --- | --- |
+| Pass | Proceed to sanctions screening | Section 5.2 |
+| Fail — document unreadable | Pending Resubmission | User notified to resubmit with clearer image |
+| Fail — document expired | Pending Resubmission | User notified to submit current document |
+| Fail — liveness not detected | Pending Resubmission | User notified to retry with video liveness session |
+| Fail — liveness spoofing detected | Escalate to Manual Review | Flagged for human review as potential fraud |
+| Fail — suspected forgery | Escalate to Manual Review | Flagged for human review |
+| Fail — data mismatch | Escalate to Manual Review | Profile data vs. document data discrepancy |
+| Inconclusive | Escalate to Manual Review | Provider unable to make a determination |
+| Provider error | Retry with backoff; if persistent, escalate to Manual Review | Operational failure, not a verification result |
+
+### 5.2 Sanctions Screening
+
+All users who pass automated verification (or manual review approval) must be screened against sanctions lists before receiving Verified status.
+
+**Sanctions lists checked**:
+
+- OFAC (U.S. Office of Foreign Assets Control) — SDN List, Consolidated Sanctions List.
+- EU Consolidated Financial Sanctions List.
+- UN Security Council Consolidated List.
+- Australian DFAT Consolidated List.
+
+**Screening approach**:
+
+- Sanctions screening is performed via the KYC provider's sanctions screening capability or a dedicated sanctions screening service, wrapped behind the same abstraction layer.
+- Screening uses name matching (with fuzzy matching for transliterations and name variations) and date-of-birth matching.
+- Screening results: Clear, Potential Match, or Confirmed Match.
+
+**Screening result handling**:
+
+| Screening Result | Action |
+| --- | --- |
+| Clear | Verification status set to Verified |
+| Potential Match | Escalated to Manual Review with sanctions match details |
+| Confirmed Match | Verification status set to Rejected — sanctions; account flagged; Administrator notified immediately; incident logged as Critical severity per [Security](L3-002), Section 10.1 |
+
+**Re-screening frequency**: Re-screening occurs as part of the 2-year re-verification cycle.
+When a user's Verified status expires (after 2 years), re-verification includes fresh sanctions screening.
+
+### 5.3 Manual Review Workflow
+
+Cases that cannot be resolved by automated verification or sanctions screening are escalated to a manual review queue.
+
+**Who can review**: Administrator and Super Administrator roles, as defined in [Security](L3-002), Section 5.1.
+MFA is required for all manual review actions per [Security](L3-002), Section 4.2.
+
+**Review queue requirements**:
+
+- Queue displays: submission date, user identifier, document type, reason for escalation, automated verification details, sanctions screening details (if applicable).
+- Queue is ordered by submission date (FIFO), with sanctions-related escalations prioritised.
+- Reviewer can view the submitted document images within a secure viewer (documents never downloaded to reviewer's local machine — rendered server-side or in a secure browser context).
+
+**Review actions**:
+
+| Action | Description | Result |
+| --- | --- | --- |
+| Approve | Reviewer confirms identity is valid | Proceeds to sanctions screening (if not yet screened) or status set to Verified (if sanctions already cleared) |
+| Request Resubmission | Document quality insufficient or additional documentation needed | Status set to Pending Resubmission; user notified with specific reason |
+| Reject | Identity cannot be verified; fraudulent or disqualifying information | Status set to Rejected; user notified with rationale |
+
+**Decision logging**: Every manual review decision is logged as a `kyc` audit event per [Audit](L3-006), Section 4.1, including:
+
+- Reviewer identity (actor_id).
+- Decision (approve / request resubmission / reject).
+- Rationale (free-text reason — mandatory field).
+- Documents reviewed (resource references, not document content).
+- Time spent in review (for operational metrics).
+
+---
+
+## 6. Verification Status Lifecycle
+
+### 6.1 Status States
+
+| Status | Description |
+| --- | --- |
+| **Not Verified** | Default state for new accounts. No KYC documents submitted. |
+| **Pending** | Documents submitted; automated verification or sanctions screening in progress. |
+| **Pending Resubmission** | Previous submission failed validation or was returned by a reviewer; awaiting new submission from user. |
+| **In Manual Review** | Automated verification inconclusive or failed; awaiting human review. |
+| **Verified** | Identity confirmed through automated verification and sanctions screening (and manual review if applicable). |
+| **Expired** | Previously verified, but verification has expired (document expiry or time-based re-verification trigger). |
+| **Re-verification Required** | A trigger event (see Section 7) requires the user to re-verify. |
+| **Rejected** | Identity verification failed with a definitive rejection. User may appeal or resubmit (see Section 6.3). |
+| **Locked** | KYC submission locked after 5 failed attempts. Requires Administrator intervention to unlock (see Section 6.3). |
+
+### 6.2 State Transitions
+
+```text
+Not Verified → Pending                     (user submits documents)
+Pending → Verified                          (automated checks + sanctions clear)
+Pending → In Manual Review                  (automated checks fail/inconclusive)
+Pending → Pending Resubmission              (document validation fails)
+In Manual Review → Verified                 (reviewer approves + sanctions clear)
+In Manual Review → Pending Resubmission     (reviewer requests resubmission)
+In Manual Review → Rejected                 (reviewer rejects)
+Pending Resubmission → Pending              (user resubmits documents)
+Verified → Expired                          (document expiry or time-based trigger)
+Verified → Re-verification Required         (regulatory change or suspicious activity)
+Expired → Pending                           (user submits new documents)
+Re-verification Required → Pending          (user submits new documents)
+Rejected → Pending                          (user resubmits after rejection — limited retries)
+Rejected → Locked                           (5th failed attempt — account locked for KYC submission)
+Locked → Pending Resubmission               (Administrator unlocks account)
+```
+
+Every state transition emits a `kyc` audit event per [Audit](L3-006).
+
+### 6.3 Rejection and Resubmission Rules
+
+- After 3 failed resubmission attempts, a customer service alert is raised for proactive outreach.
+- After 5 failed resubmission attempts, the KYC status transitions to Locked. The user cannot submit new documents until an Administrator unlocks the account, which transitions the status to Pending Resubmission.
+- When an Administrator unlocks an account, the failure counter resets to zero.
+- Each resubmission resets the verification flow from the beginning (new document upload, new automated verification).
+- Rejection rationale is stored and visible to the user (sanitised — no internal review notes exposed) and to administrators (full detail).
+
+---
+
+## 7. Re-verification Triggers
+
+Verified status is not permanent.
+The following events trigger a transition to Expired or Re-verification Required:
+
+| Trigger | New Status | Rationale |
+| --- | --- | --- |
+| Identity document expiry date reached | Expired | Document no longer valid; fresh verification needed |
+| Time-based re-verification period elapsed (2 years from verification date) | Expired | Verified status expires 2 years after verification, requiring full re-verification |
+| Regulatory change affecting verification requirements | Re-verification Required | New regulations may require additional checks or different documents |
+| Suspicious activity flag from [Audit](L3-006) anomaly detection | Re-verification Required | Anomalous patterns warrant identity re-confirmation |
+| User changes legal name or nationality in profile | Re-verification Required | Identity documents must match current profile data |
+| Sanctions list update results in potential match for previously verified user | Re-verification Required | Re-screening against updated lists produces a match requiring review |
+
+**Impact of non-Verified status on dependent systems**:
+
+- **Campaign submission**: Users without Verified KYC status cannot submit new campaigns.
+  Existing live campaigns are not immediately affected but new milestone disbursements are paused — see [Campaign](L4-002) interface contract.
+- **Disbursements**: Users without Verified KYC status are ineligible for disbursements — see [Payments](L4-004) interface contract.
+- **Creator role**: The Creator role is conditional on Verified KYC status per [Security](L3-002), Section 5.2.
+  If KYC status transitions to Expired or Re-verification Required, Creator role capabilities are suspended until re-verification completes.
+
+---
+
+## 8. Identity Document Storage and Retention
+
+### 8.1 Storage Requirements
+
+Identity documents are classified as **Restricted** per [Data Management](L3-004), Section 1.1.
+
+- Encrypted at rest with AES-256 per [Engineering Standard](L2-002), Section 1.1.
+- Stored in a dedicated, isolated storage service — not in the same data store as general application data.
+- Uploaded files served from a separate domain per [Engineering Standard](L2-002), Section 1.4.
+- Access requires Restricted-level authorisation with MFA per [Data Management](L3-004), Section 5.1.
+- All access to stored documents is logged and alerted per [Data Management](L3-004), Section 5.1.
+
+### 8.2 What Is Stored
+
+| Data Element | Classification | Retention |
+| --- | --- | --- |
+| Original document images | Restricted | Per Section 8.3 |
+| Extracted document data (name, DOB, document number, expiry) | Restricted | Per Section 8.3 |
+| Verification result (pass/fail, confidence score, provider reference) | Restricted | Per Section 8.3 |
+| Sanctions screening result | Restricted | Per Section 8.3 |
+| Manual review decision and rationale | Restricted | Per Section 8.3 |
+| Video liveness session result (pass/fail, provider reference) | Restricted | Per Section 8.3 |
+| Verification status history (state transitions with timestamps) | Confidential | Per Section 8.3 |
+
+Video liveness capture footage (video frames, biometric data) is retained only by Veriff and is not stored in the Mars Mission Fund platform.
+Only the session result and provider reference are stored locally.
+
+### 8.3 Retention Policy
+
+Per [Data Management](L3-004), Section 2.1:
+
+| Data Type | Active Retention | Archive Retention | Total | Regulatory Driver |
+| --- | --- | --- | --- | --- |
+| KYC identity documents and extracted data | Duration of active account + 1 year | 7 years from account closure | ~8+ years | AML/CTF Act (Australia), GDPR |
+| Sanctions screening results | Duration of active account + 1 year | 7 years from account closure | ~8+ years | AML/CTF Act |
+| Verification decisions and rationale | Duration of active account + 1 year | 7 years from account closure | ~8+ years | AML/CTF Act |
+| Verification status history | Duration of active account | 30 days after account closure (then anonymised) | Account lifetime + 30 days | GDPR |
+
+### 8.4 Right-to-Erasure Handling
+
+When a data subject exercises their right to erasure (GDPR Article 17):
+
+- KYC identity documents and verification records are **exempt from immediate deletion** where AML/CTF retention requirements apply.
+  The legal obligation to retain identity records for anti-money laundering purposes overrides the right to erasure per GDPR Article 17(3)(b) — compliance with a legal obligation.
+- The data subject is informed that certain identity records are retained under legal obligation and provided with the regulatory basis.
+- Once the AML/CTF retention period expires, data is deleted in accordance with the right-to-erasure workflow defined in [Data Management](L3-004), Section 4.5.
+- Verification status history (non-regulated) is anonymised or deleted per the standard erasure workflow.
+
+### 8.5 Deletion on Account Deactivation
+
+When a user deactivates their account:
+
+- Verification status is set to a terminal state (account deactivated).
+- Identity documents and verification records enter the archive retention phase per Section 8.3.
+- After archive retention expires, all KYC data is permanently deleted.
+- Deletion is logged as an audit event per [Audit](L3-006).
+
+---
+
+## 9. Auditable Events
+
+All KYC events are logged as `kyc`-type audit events per [Audit](L3-006), Section 4.1.
+The following events must be logged:
+
+| Event | Audit Action | Logged Fields (in addition to base schema) |
+| --- | --- | --- |
+| Document uploaded | `kyc.document.upload` | Document type, file metadata (size, format), user ID |
+| Automated verification initiated | `kyc.verification.start` | Provider reference, document type |
+| Automated verification result received | `kyc.verification.result` | Provider reference, result (pass/fail/inconclusive), confidence score (if available) |
+| Sanctions screening initiated | `kyc.sanctions.start` | Lists checked, user identity reference |
+| Sanctions screening result received | `kyc.sanctions.result` | Result (clear/potential match/confirmed match), lists checked |
+| Escalated to manual review | `kyc.review.escalate` | Reason for escalation, queue position |
+| Manual review decision | `kyc.review.decision` | Reviewer ID, decision (approve/resubmit/reject), rationale |
+| Status transition | `kyc.status.change` | Previous status, new status, trigger reason |
+| Re-verification triggered | `kyc.reverification.trigger` | Trigger type (document expiry, suspicious activity, etc.) |
+| Document accessed | `kyc.document.access` | Accessor ID, access purpose, document reference |
+| Document deleted (retention expiry) | `kyc.document.delete` | Deletion reason (retention expiry, account deactivation), document reference |
+| Resubmission threshold reached (3 attempts) | `kyc.resubmission.cs_alert` | User ID, attempt count, failure history summary |
+| Account locked for KYC submission (5 attempts) | `kyc.resubmission.account_locked` | User ID, attempt count, failure history summary |
+| Account unlocked for KYC submission (admin intervention) | `kyc.resubmission.account_unlocked` | User ID, admin actor ID, unlock rationale |
+
+**Sensitive data rules**: Document content, PII extracted from documents, and raw sanctions screening details are never included in audit log entries.
+Only resource identifiers and result classifications are logged, per [Audit](L3-006), Section 3.3.
+
+---
+
+## 10. Interface Contracts
+
+### 10.1 KYC <> Account (L4-001)
+
+| This Spec Provides | Account Spec Consumes |
+| --- | --- |
+| KYC verification status for each user (see Section 6.1 for status values) | Account verification state — [Account](L4-001) displays KYC status to the user and gates Creator role eligibility |
+| KYC status change events | [Account](L4-001) updates user-facing verification state and triggers notifications on status changes |
+| Re-verification required notifications | [Account](L4-001) surfaces re-verification prompts to the user |
+
+**Integration mechanism**: KYC service exposes a status query API and publishes status change events.
+[Account](L4-001) subscribes to status change events and queries current status as needed.
+
+### 10.2 KYC <> Payments (L4-004)
+
+| This Spec Provides | Payments Spec Consumes |
+| --- | --- |
+| KYC verification status (Verified / not Verified) | [Payments](L4-004) checks KYC status before processing disbursements — only users with Verified status are eligible for disbursement |
+| KYC status change events (specifically: Verified → Expired or Re-verification Required) | [Payments](L4-004) pauses pending disbursements when KYC status leaves Verified state |
+
+**Integration mechanism**: [Payments](L4-004) queries KYC status synchronously before disbursement processing and subscribes to status change events for proactive disbursement holds.
+
+### 10.3 KYC <> Campaign (L4-002)
+
+| This Spec Provides | Campaign Spec Consumes |
+| --- | --- |
+| KYC verification status (Verified / not Verified) | [Campaign](L4-002) checks KYC status before allowing project submission — only users with Verified status can submit campaigns |
+| KYC status change events | [Campaign](L4-002) may use status changes to update campaign eligibility for existing campaigns |
+
+**Integration mechanism**: [Campaign](L4-002) queries KYC status synchronously at project submission time.
+
+### 10.4 KYC <> Security (L3-002)
+
+| This Spec Provides | Security Spec Provides |
+| --- | --- |
+| Verification lifecycle that determines Creator role eligibility | RBAC model, role assignment rules, MFA requirements for KYC admin operations |
+| Sanctions screening results that may trigger security incident response | Incident response process for sanctions matches (Critical severity) |
+
+Reference: [Security](L3-002), Section 12.7.
+
+### 10.5 KYC <> Data Management (L3-004)
+
+| This Spec Provides | Data Management Spec Provides |
+| --- | --- |
+| Specific KYC document types and verification workflows | Restricted classification for KYC documents, retention schedule, right-to-erasure handling rules |
+| Definition of which identity records are legally required to be retained post-erasure request | Anonymisation and deletion enforcement mechanism |
+
+Reference: [Data Management](L3-004), Section 9.5.
+
+### 10.6 KYC <> Audit (L3-006)
+
+| This Spec Provides | Audit Spec Provides |
+| --- | --- |
+| KYC-specific audit events (Section 9) logged as `kyc` event type | Immutable logging infrastructure, event schema, retention (7 years for KYC events), anomaly detection |
+| Suspicious activity patterns (repeated failures, unusual submission patterns) for anomaly detection | Anomaly detection alerts that trigger re-verification (Section 7) |
+
+Reference: [Audit](L3-006), Section 11.5.
+
+---
+
+## 11. Acceptance Criteria
+
+### Document Upload
+
+**AC-KYC-001**: Given a user with Not Verified status, when they upload a valid identity document (correct format, within size limits, legible), then the document is stored with Restricted-level encryption and the KYC status transitions to Pending.
+
+**AC-KYC-002**: Given a user uploading a document, when the file fails type validation (invalid format or magic bytes), then the upload is rejected with a user-friendly error message and KYC status remains unchanged.
+
+**AC-KYC-003**: Given a user uploading a document, when the file exceeds 20 MB, then the upload is rejected with a user-friendly error message indicating the size constraint.
+
+### Automated Verification
+
+**AC-KYC-004**: Given a user with Pending status and a valid document uploaded, when the automated verification returns a pass result, then the system proceeds to sanctions screening without manual intervention.
+
+**AC-KYC-005**: Given a user with Pending status, when the automated verification returns a failure or inconclusive result, then the case is escalated to the manual review queue and the KYC status transitions to In Manual Review.
+
+**AC-KYC-006**: Given a user with Pending status, when the automated verification indicates the document is unreadable or expired, then the KYC status transitions to Pending Resubmission and the user is notified with the specific reason.
+
+**AC-KYC-006a**: Given a user with Pending status, when the liveness check fails to detect a live person, then the KYC status transitions to Pending Resubmission and the user is notified to retry the video liveness session.
+
+**AC-KYC-006b**: Given a user with Pending status, when the liveness check detects spoofing (e.g., photo of a photo, pre-recorded video), then the case is escalated to the manual review queue and the KYC status transitions to In Manual Review.
+
+### Sanctions Screening
+
+**AC-KYC-007**: Given a user who has passed automated verification (or manual review approval), when sanctions screening returns Clear, then the KYC status transitions to Verified.
+
+**AC-KYC-008**: Given a user undergoing sanctions screening, when screening returns a Potential Match, then the case is escalated to the manual review queue with sanctions match details attached.
+
+**AC-KYC-009**: Given a user undergoing sanctions screening, when screening returns a Confirmed Match, then the KYC status transitions to Rejected, the account is flagged, an Administrator is notified immediately, and a Critical-severity security incident is logged.
+
+### Manual Review
+
+**AC-KYC-010**: Given a case in the manual review queue, when an Administrator approves the identity, then the case proceeds to sanctions screening (if not yet screened) or KYC status transitions to Verified (if sanctions already cleared), and the decision with rationale is logged as an audit event.
+
+**AC-KYC-011**: Given a case in the manual review queue, when an Administrator requests resubmission, then the KYC status transitions to Pending Resubmission, the user is notified with the specific reason, and the decision is logged.
+
+**AC-KYC-012**: Given a case in the manual review queue, when an Administrator rejects the identity with a rationale, then the KYC status transitions to Rejected, the user is notified with a sanitised rationale, and the full decision is logged.
+
+**AC-KYC-013**: Given a reviewer attempting a manual review action, when they have not completed MFA for the current session, then the action is blocked until MFA is satisfied.
+
+### Resubmission Escalation
+
+**AC-KYC-013a**: Given a user who has failed KYC verification 3 times, when the third failure occurs, then a customer service alert is raised for proactive outreach to the user.
+
+**AC-KYC-013b**: Given a user who has failed KYC verification 5 times, when the fifth failure occurs, then the KYC status transitions to Locked, the user cannot submit new documents, and an Administrator must unlock the account to allow further submissions.
+
+**AC-KYC-013c**: Given a user with Locked KYC status, when an Administrator unlocks the account, then the KYC status transitions to Pending Resubmission, the user is notified that they can resubmit, and the unlock decision is logged as an audit event.
+
+### Re-verification
+
+**AC-KYC-014**: Given a user with Verified status, when their identity document's expiry date is reached, then the KYC status transitions to Expired and the user is notified to re-verify.
+
+**AC-KYC-015**: Given a user with Verified status, when a suspicious activity flag is raised by the anomaly detection system, then the KYC status transitions to Re-verification Required and the user is notified.
+
+**AC-KYC-015a**: Given a user with Verified status, when 2 years have elapsed since their verification date, then the KYC status transitions to Expired and the user is notified to re-verify.
+
+**AC-KYC-016**: Given a user with Expired or Re-verification Required status, when they submit new identity documents, then the KYC status transitions to Pending and the full verification flow restarts.
+
+### Data Retention and Deletion
+
+**AC-KYC-017**: Given a user who has deactivated their account, when the archive retention period (7 years from account closure) expires, then all KYC identity documents and verification records are permanently deleted and the deletion is logged as an audit event.
+
+**AC-KYC-018**: Given a data subject exercising their right to erasure, when AML/CTF retention requirements apply to their KYC records, then the system retains the records for the legally required period, informs the data subject of the legal basis for retention, and deletes the records once the retention obligation expires.
+
+### Audit Trail
+
+**AC-KYC-019**: Given any KYC status transition, when the transition occurs, then a `kyc` audit event is emitted containing the previous status, new status, trigger reason, and actor identity, with no sensitive document content included.
+
+**AC-KYC-020**: Given an Administrator accessing a stored identity document for manual review, then the access is logged as a `kyc.document.access` audit event with the accessor's identity and stated purpose.
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| --- | --- | --- | --- |
+| March 2026 | 0.1 | — | Initial stub. KYC verification flow, document types and jurisdictional requirements, automated verification with provider abstraction, sanctions screening (OFAC, EU, UN, Australian DFAT), manual review workflow, verification status lifecycle (eight states), re-verification triggers, identity document storage and retention (Restricted classification, AML/CTF retention), right-to-erasure handling, auditable events, interface contracts with Account/Payments/Campaign/Security/Data Management/Audit, acceptance criteria. |
+| March 2026 | 0.2 | — | Closed open questions OQ-2 through OQ-6 and OQ-8. Resolved: video liveness check required, 20 MB max file size, 3/5-attempt resubmission escalation, 2-year re-verification period, sanctions re-screening at re-verification, launch countries AU/US/UK/EU. Updated spec body to reflect resolved values. |
+| March 2026 | 0.3 | — | Added Locked status to lifecycle (9 states). Added Depended On By for L4-002 and L4-004. Added video liveness to governs list and Australian DFAT to sanctions list reference. Added liveness data storage clarification (retained by Veriff only). Added audit events for resubmission escalation thresholds and account unlock. Added AC-KYC-013c for admin unlock. |

--- a/specs/domain/payments.md
+++ b/specs/domain/payments.md
@@ -1,0 +1,525 @@
+# Payment Processing
+
+> **Spec ID**: L4-004
+> **Version**: 0.3
+> **Status**: Approved
+> **Rate of Change**: Per feature / per release
+> **Depends On**: L2-002 (Engineering Standard), L3-001 (Architecture), L3-002 (Security), L3-004 (Data Management), L3-006 (Audit)
+> **Depended On By**: L4-002 (Campaign), L4-003 (Donor)
+
+---
+
+## 1. Purpose
+
+> **Local demo scope**: The payment gateway abstraction layer, contribution state machine, and escrow ledger design are **real** — they demonstrate the architectural pattern in the local demo. The actual payment gateway is **stubbed** (no real money moves). Multi-approval disbursement workflow, daily reconciliation, and refund processing are theatre. The local demo simulates payment success/failure without a live gateway.
+
+This spec governs all payment processing within Mars Mission Fund: how money enters the platform (contributions), how it is held (escrow), how it is released (milestone disbursement), and how it is returned (refunds).
+
+**In scope**:
+
+- Payment gateway integration and abstraction.
+- Card tokenisation and PCI DSS scope management.
+- Contribution processing (authorisation, capture, escrow hold).
+- Escrow account structure and lifecycle.
+- Milestone-based disbursement with multi-approval workflow.
+- Refund handling (full and partial).
+- Currency support.
+- Transaction reconciliation.
+- Tax receipt data generation.
+- Financial reporting and admin dashboards.
+
+**Out of scope**:
+
+- Campaign lifecycle and milestone definition — governed by [Campaign](L4-002).
+- Donor-facing contribution UI and discovery flows — governed by [Donor](L4-003).
+- KYC verification process — governed by [KYC](L4-005).
+  This spec receives KYC status as a gate; it does not perform verification.
+- Identity and access management — governed by [Account](L4-001) and [Security](L3-002).
+
+---
+
+## 2. Inherited Constraints
+
+### From [Engineering Standard](L2-002)
+
+- **Section 1.1 (Encryption)**: All payment data encrypted in transit (TLS 1.3 minimum) and at rest (AES-256).
+  Financial data is classified as sensitive under the data classification scheme.
+- **Section 1.2 (Data Access)**: All database queries use parameterised queries via a data access layer.
+  No raw SQL in payment service code.
+- **Section 1.3 (Secrets Management)**: Gateway API keys, signing secrets, and webhook secrets managed through the secrets management service.
+  Never stored in source code or configuration files.
+- **Section 1.4 (Input Validation)**: All external input (webhook payloads, API requests, callback URLs) validated at the system boundary.
+- **Section 1.5 (Authentication & Authorisation)**: Every payment API endpoint authenticated and authorised.
+  MFA required for all financial actions (contributions, disbursements, refunds).
+- **Section 1.7 (Logging & Auditability)**: Every payment state mutation logged with timestamp, actor, action, and affected resource.
+  Sensitive financial data (card numbers, bank account details) never logged.
+- **Section 2.4 (Abstraction Requirement)**: Payment gateway accessed through an internal adapter interface.
+  No application code references the gateway vendor SDK directly.
+- **Section 4.2 (Test Coverage)**: 100% coverage of success and failure paths for all payment flows (integration + end-to-end tests).
+- **Section 4.5 (Deployment Gates)**: Production deployments to payment flows require a second approval from an engineer who did not author the change.
+
+### From L3 Technical Specs
+
+- **[Architecture](L3-001)**: Service boundaries, inter-service communication patterns, and data model constraints applicable to the payment service.
+- **[Security](L3-002)**: PCI DSS compliance scope, threat model for payment flows, authentication mechanism for payment endpoints, and encryption key management.
+- **[Data Management](L3-004)**: Data classification for financial records, retention policies for transaction data, and backup/recovery requirements for payment state.
+- **[Audit](L3-006)**: Immutable audit trail for all payment events, retention periods for financial audit data, and regulatory reporting requirements.
+
+---
+
+## 3. Payment Gateway Integration
+
+### 3.1 Gateway Selection
+
+**Resolved**: Stripe is the primary payment gateway.
+
+Stripe is selected for:
+
+- Comprehensive API coverage (authorisation, capture, void, refund, payouts).
+- Client-side tokenisation via Stripe Elements (maintains SAQ-A compliance).
+- Stripe Connect support for marketplace/escrow-style fund flows.
+- Strong webhook infrastructure with signature verification.
+- Excellent developer experience, documentation, and TypeScript SDK.
+
+The adapter abstraction (Section 3.2) remains in place — application code does not reference the Stripe SDK directly. This preserves the ability to swap or add gateways in future.
+
+### 3.2 Abstraction Layer
+
+Per [Engineering Standard](L2-002), Section 2.4, all gateway interaction is wrapped behind an internal payment gateway adapter.
+
+The adapter interface must support:
+
+- Authorisation (pre-auth hold on a payment method).
+- Capture (convert an authorisation to a charge).
+- Void (cancel an uncaptured authorisation).
+- Refund (full or partial reversal of a captured charge).
+- Webhook event processing (normalise gateway-specific event formats).
+- Payment method tokenisation (delegate to gateway's client-side tokenisation).
+
+The adapter returns normalised domain events regardless of the underlying gateway.
+Consuming code never sees gateway-specific types, error codes, or response formats.
+
+### 3.3 Webhook Handling
+
+Gateway webhooks must be:
+
+- Verified using the gateway's signature verification mechanism before processing.
+- Idempotent — processing the same webhook event twice produces the same outcome.
+- Processed asynchronously with at-least-once delivery semantics.
+- Logged in the audit trail per [Audit](L3-006).
+
+---
+
+## 4. Tokenisation & PCI DSS Scope
+
+### 4.1 Scope Target
+
+Mars Mission Fund targets **PCI DSS SAQ-A** compliance scope.
+The platform never stores, processes, or transmits raw card data.
+All card data handling is delegated to Stripe's client-side tokenisation via Stripe Elements.
+
+### 4.2 Tokenisation Flow
+
+1. The donor's browser/client communicates directly with the payment gateway to tokenise card details.
+1. The gateway returns a single-use payment method token.
+1. The platform's backend receives only the token — never raw card data.
+1. The token is used for the immediate capture operation.
+   Refunds reference the resulting charge/payment ID, not the original token.
+
+### 4.3 Stored Payment Methods
+
+**Resolved**: Stored payment methods are not supported.
+Donors must re-enter payment details for each contribution.
+This minimises PCI scope and reduces token storage obligations.
+This decision may be revisited in a future release to improve repeat donor experience.
+
+---
+
+## 5. Contribution Processing Flow
+
+### 5.1 Flow Overview
+
+**Resolved**: Immediate capture.
+Funds are authorised and captured in a single step at contribution time.
+This eliminates authorisation expiry risk and ensures funds are held in escrow immediately.
+Interest accrues on escrowed funds from the moment of capture until disbursement (see Section 6.3).
+
+```text
+Donor initiates contribution
+    → Tokenise card (client-side, gateway)
+    → Authorise and capture payment (backend → gateway adapter)
+    → Create escrow record; funds held in campaign's segregated escrow account
+    → Confirm contribution to donor
+    → Notify campaign of new contribution
+```
+
+### 5.2 Authorisation and Capture
+
+- Authorisation and capture occur as a single immediate operation.
+- The charge includes metadata: campaign ID, donor ID, contribution ID, and timestamp.
+- On successful capture, funds are routed to the campaign's segregated escrow account (see Section 6.1).
+- Capture failure triggers a retry strategy (defined in [Reliability](L3-003)) and donor notification.
+
+### 5.3 Contribution States
+
+| State | Description |
+| --- | --- |
+| `pending_capture` | Capture request sent to gateway. |
+| `captured` | Funds captured and held in escrow. |
+| `failed` | Capture failed. |
+| `refunded` | Contribution fully refunded. |
+| `partially_refunded` | Contribution partially refunded. |
+
+Every state transition is logged in the audit trail per [Audit](L3-006).
+
+---
+
+## 6. Escrow Mechanics
+
+### 6.1 Escrow Structure
+
+**Resolved**: Segregated escrow accounts — one per campaign.
+
+Each campaign has its own dedicated escrow account.
+Contributed funds are held in the campaign's segregated account until milestones are verified and disbursement is approved.
+This provides clear legal separation, simplifies per-campaign accounting, and eliminates cross-campaign fund commingling risk.
+
+> **Workshop note**: Segregated accounts are the architectural design.
+> In the local demo, this may be represented as logical separation within a single data store rather than actual separate bank accounts.
+
+### 6.2 Escrow Ledger
+
+Each segregated escrow account is backed by a double-entry ledger tracking:
+
+- Per-campaign escrow balance.
+- Per-contribution escrow allocation.
+- Disbursement debits.
+- Refund debits.
+- Interest credits.
+
+The ledger is append-only and immutable per [Engineering Standard](L2-002), Section 1.7.
+
+### 6.3 Interest Handling
+
+**Resolved**: Interest earned on escrowed funds is passed to the campaign.
+
+- Interest accrues from the moment of capture until disbursement.
+- Accrued interest is included with the milestone disbursement payment to the campaign creator.
+- If a campaign fails and contributions are refunded, any accrued interest is returned to donors pro-rata along with their contribution refund.
+- Interest calculations and disbursement are recorded in the escrow ledger and audit trail.
+
+---
+
+## 7. Milestone-Based Disbursement
+
+### 7.1 Disbursement Trigger
+
+Disbursement is triggered when a campaign milestone is verified as complete per [Campaign](L4-002).
+This spec receives a disbursement trigger event from the campaign domain — it does not determine whether a milestone is met.
+
+### 7.2 Multi-Approval Workflow
+
+Per [Product Vision & Mission](L1-001), disbursement of escrowed funds requires dual authorisation:
+
+- **Two administrators** must independently approve each disbursement.
+- The two approvers must be different individuals (no self-approval).
+- Approvals are time-bounded — if the second approval does not occur within a configured window, the first approval expires and the process must restart.
+- Each approval is logged in the audit trail with the approver's identity and timestamp.
+
+### 7.3 Disbursement Processing
+
+1. Campaign milestone verified → disbursement request created.
+1. First administrator approves.
+1. Second administrator approves.
+1. KYC status confirmed as current for the creator per [KYC](L4-005) — disbursement is blocked if KYC has expired or been revoked.
+1. Accrued interest on the disbursement portion calculated and added to the payout amount (see Section 6.3).
+1. Payout executed via gateway adapter to campaign creator's verified bank account.
+1. Escrow ledger debited for principal and interest; disbursement recorded.
+
+### 7.4 Disbursement States
+
+| State | Description |
+| --- | --- |
+| `pending_approval` | Awaiting first administrator approval. |
+| `partially_approved` | First approval received; awaiting second. |
+| `approved` | Dual approval complete; ready for payout. |
+| `processing` | Payout initiated with gateway. |
+| `completed` | Funds transferred to creator. |
+| `failed` | Payout failed; requires investigation. |
+| `approval_expired` | Approval window elapsed; must restart. |
+
+---
+
+## 8. Refund Handling
+
+### 8.1 Refund Triggers
+
+- **Campaign failure**: If a campaign fails to meet its funding goal by the deadline, all contributions are refunded in full.
+  The failure event is received from [Campaign](L4-002).
+- **Campaign cancellation**: If a campaign is cancelled by administrators, all contributions are refunded.
+- **Donor-initiated refund**: Subject to the milestone-based refund policy (see Section 8.5).
+
+### 8.2 Refund Processing
+
+1. Refund event received (campaign failure, cancellation, or donor request).
+1. Refund eligibility validated against policy.
+1. Refund initiated via gateway adapter (full or partial).
+1. Escrow ledger debited for the refund amount.
+1. Donor notified of refund and expected timeline.
+1. Refund status tracked through to settlement.
+
+### 8.3 Refund States
+
+| State | Description |
+| --- | --- |
+| `pending` | Refund initiated; processing with gateway. |
+| `completed` | Refund confirmed by gateway; funds returned to donor. |
+| `failed` | Refund failed; requires manual investigation. |
+
+### 8.4 Partial Refunds
+
+If a campaign has partially disbursed (some milestones completed, others not), only the undisbursed portion is eligible for refund.
+The refund amount per donor is calculated pro-rata based on their contribution relative to total campaign escrow.
+
+### 8.5 Donor-Initiated Refund Policy
+
+**Resolved**: Milestone-based refund policy.
+
+Donor-initiated refunds are governed by the campaign's disbursement state:
+
+- **No milestones disbursed**: Full refund available.
+  The donor may request a full refund of their contribution at any time before the first milestone disbursement.
+- **Partial disbursement**: Pro-rata refund of undisbursed portion.
+  If some milestones have been disbursed, the donor may request a refund of their proportional share of the remaining escrow balance.
+- **Fully disbursed**: No refund available.
+  Once all milestones have been disbursed, no refund is possible.
+
+Refund requests are processed within 5–10 business days.
+All refund requests and outcomes are logged in the audit trail.
+
+---
+
+## 9. Currency Support
+
+**Resolved**: Single currency — USD.
+
+### 9.1 Single Currency
+
+- All contributions and disbursements are in USD.
+- Amounts stored as integer minor units (cents) to avoid floating-point precision issues.
+- Display formatting handled by the frontend per [Frontend Standards](L3-005).
+- Multi-currency support is out of scope and may be considered in a future release.
+
+---
+
+## 10. Transaction Reconciliation
+
+### 10.1 Daily Reconciliation
+
+A daily automated reconciliation process compares:
+
+- Platform transaction records against gateway settlement reports.
+- Escrow ledger balances against actual account balances.
+- Disbursement records against gateway payout confirmations.
+
+### 10.2 Discrepancy Handling
+
+- Discrepancies are flagged automatically and create an investigation ticket.
+- Discrepancies above a configurable threshold trigger an alert to the finance team.
+- No automated resolution of discrepancies — all resolutions require human review and are logged in the audit trail.
+
+### 10.3 Reconciliation Report
+
+A reconciliation report is generated daily and includes:
+
+- Total contributions processed vs gateway settlement.
+- Total disbursements processed vs gateway payouts.
+- Escrow balance: expected (ledger) vs actual (account).
+- List of unresolved discrepancies.
+
+---
+
+## 11. Tax Receipt Data
+
+### 11.1 Data Provided to Donor Spec
+
+This spec provides financial data to [Donor](L4-003) for tax receipt generation.
+Tax receipt generation and delivery is the responsibility of the donor domain.
+
+Data provided per contribution:
+
+- Contribution ID.
+- Donor ID.
+- Campaign ID and campaign name.
+- Contribution amount (gross).
+- Currency.
+- Date of contribution (capture date).
+- Payment method type (card, bank transfer — not card details).
+- Refund amount (if any).
+- Platform tax-exempt status identifier.
+
+### 11.2 Financial Year Aggregation
+
+The payment service provides aggregated contribution data per donor per financial year on request from [Donor](L4-003).
+
+**Resolved**: Mars Mission Fund is a tax-deductible entity.
+Contributions qualify for tax deductibility.
+Tax receipts must include the platform's tax-exempt status identifier and comply with applicable tax authority requirements.
+Receipt wording must clearly state the deductible amount (gross contribution minus any refunds).
+
+---
+
+## 12. Financial Reporting
+
+### 12.1 Admin Dashboard Metrics
+
+The payment service exposes financial data for the admin dashboard:
+
+| Metric | Description |
+| --- | --- |
+| Total raised | Sum of all captured contributions across all campaigns. |
+| Total disbursed | Sum of all completed disbursements (principal). |
+| Total interest disbursed | Sum of all interest paid out to campaigns. |
+| Total in escrow | Current escrow balance across all campaigns (principal + accrued interest). |
+| Total refunded | Sum of all completed refunds (principal + interest). |
+| Net platform position | Total raised + total interest earned − disbursed − interest disbursed − refunded. |
+
+### 12.2 Per-Campaign Financials
+
+For each campaign:
+
+- Total contributions (count and amount).
+- Escrow balance (principal + accrued interest).
+- Accrued interest to date.
+- Disbursed to date (principal + interest, per milestone).
+- Refunds processed.
+- Funding progress (percentage of goal).
+
+### 12.3 Reporting Access Control
+
+Financial reports are restricted to users with the appropriate administrative role per [Security](L3-002).
+All report access is logged in the audit trail.
+
+---
+
+## 13. Interface Contracts
+
+### 13.1 Interface with [Campaign](L4-002)
+
+| Direction | Event / Data | Description |
+| --- | --- | --- |
+| Campaign → Payments | `escrow_create` | When a campaign is approved and goes live, an escrow allocation is created. |
+| Campaign → Payments | `milestone_verified` | When a campaign milestone is verified, triggers disbursement workflow. |
+| Campaign → Payments | `campaign_failed` | When a campaign fails (deadline reached, goal not met), triggers full refund of all contributions. |
+| Campaign → Payments | `campaign_cancelled` | When a campaign is cancelled by administrators, triggers full refund. |
+| Payments → Campaign | `contribution_received` | Confirms a new contribution has been captured and added to escrow. |
+| Payments → Campaign | `disbursement_completed` | Confirms milestone disbursement has been transferred. |
+| Payments → Campaign | `escrow_balance` | Current escrow balance for a campaign (on request). |
+
+### 13.2 Interface with [Donor](L4-003)
+
+| Direction | Event / Data | Description |
+| --- | --- | --- |
+| Donor → Payments | `contribution_initiated` | Donor has chosen to contribute; payment processing begins. |
+| Payments → Donor | `contribution_confirmed` | Payment captured successfully; contribution recorded. |
+| Payments → Donor | `contribution_failed` | Payment failed; donor should retry or use a different method. |
+| Payments → Donor | `refund_initiated` | Refund processing has begun. |
+| Payments → Donor | `refund_completed` | Refund confirmed; funds returned. |
+| Payments → Donor | `tax_receipt_data` | Financial data for tax receipt generation (see Section 11). |
+
+### 13.3 Interface with [KYC](L4-005)
+
+| Direction | Event / Data | Description |
+| --- | --- | --- |
+| Payments → KYC | `kyc_status_check` | Before disbursement, payments verifies the creator's KYC status is current. |
+| KYC → Payments | `kyc_status_response` | Confirmed/denied — gates disbursement processing. |
+
+### 13.4 Interface with [Audit](L3-006)
+
+All payment state mutations emit audit events per [Engineering Standard](L2-002), Section 1.7.
+The audit event schema for payment events includes: event type, correlation ID, actor ID, timestamp, contribution/disbursement/refund ID, amount, currency, old state, new state, and gateway reference ID.
+
+### 13.5 Interface with [Account](L4-001)
+
+| Direction | Event / Data | Description |
+| --- | --- | --- |
+| Account → Payments | Authenticated identity | All payment operations receive the authenticated account ID from the session context. Payment methods are managed within the Payments domain, not Account. |
+| Payments → Account | `escrow_status` | During account deactivation, [Account](L4-001) queries Payments for active escrow positions associated with the account. Active contributions in escrow are not affected by deactivation — the escrow lifecycle continues. |
+
+Reference: [Account](L4-001), Section 8.4.
+
+---
+
+## 14. Acceptance Criteria
+
+### Contribution Processing
+
+**AC-PAY-001**: Given a donor has a valid payment method token, when they submit a contribution to a live campaign, then the payment is immediately captured, the contribution is recorded in the campaign's segregated escrow ledger, and the donor receives a confirmation including a tax-deductible receipt.
+
+**AC-PAY-002**: Given a payment capture fails (insufficient funds, card declined), when the gateway returns a failure, then the contribution is marked as `failed`, the donor is notified with a clear error message, and no funds are held.
+
+**AC-PAY-003**: Given a donor submits a duplicate contribution (same donor, same campaign, same amount within a short time window), when the system detects the duplicate, then the second attempt is rejected or flagged for confirmation, preventing accidental double charges.
+
+### Escrow
+
+**AC-PAY-004**: Given a contribution has been captured, when the escrow ledger is updated, then the campaign's escrow balance reflects the new contribution and the ledger entry is immutable.
+
+**AC-PAY-005**: Given the escrow ledger records for a campaign, when the balances are summed (contributions + interest credits − disbursements − refunds), then the result matches the actual escrow account balance for that campaign.
+
+### Disbursement
+
+**AC-PAY-006**: Given a campaign milestone has been verified, when an administrator submits a disbursement approval, then the disbursement enters `partially_approved` state and awaits a second approval from a different administrator.
+
+**AC-PAY-007**: Given a disbursement has received one approval, when a second different administrator approves, then the disbursement is processed and funds are transferred to the campaign creator's bank account.
+
+**AC-PAY-008**: Given a disbursement has received one approval, when the approval window expires before a second approval, then the disbursement returns to `pending_approval` and both approvals must be resubmitted.
+
+**AC-PAY-009**: Given a disbursement is approved, when the campaign creator's KYC status is not current (expired or revoked), then the disbursement is blocked and an alert is raised to administrators.
+
+### Refunds
+
+**AC-PAY-010**: Given a campaign has failed (deadline passed, goal not met), when the failure event is received, then all contributions to that campaign are refunded in full and donors are notified.
+
+**AC-PAY-011**: Given a campaign has partially disbursed (some milestones completed), when the campaign fails for remaining milestones, then only the undisbursed portion is refunded pro-rata to donors.
+
+**AC-PAY-012**: Given a refund is initiated, when the gateway processes the refund, then the escrow ledger is debited, the contribution state is updated to `refunded` or `partially_refunded`, and the donor is notified.
+
+### Donor-Initiated Refunds
+
+**AC-PAY-018**: Given no milestones have been disbursed for a campaign, when a donor requests a refund, then their full contribution is refunded.
+
+**AC-PAY-019**: Given some milestones have been disbursed for a campaign, when a donor requests a refund, then they receive a pro-rata refund of the undisbursed escrow balance proportional to their contribution.
+
+**AC-PAY-020**: Given all milestones have been disbursed for a campaign, when a donor requests a refund, then the request is rejected and the donor is informed that no funds remain in escrow.
+
+### Interest
+
+**AC-PAY-021**: Given funds are held in a campaign's segregated escrow account, when a milestone disbursement is processed, then accrued interest on the disbursed portion is included in the payout to the campaign creator and recorded in the escrow ledger.
+
+**AC-PAY-022**: Given a campaign has failed and contributions are being refunded, when refunds are processed, then accrued interest is returned to donors pro-rata along with their contribution refund.
+
+### Reconciliation
+
+**AC-PAY-013**: Given the daily reconciliation process runs, when platform records are compared against gateway settlement data, then any discrepancies are flagged, and a reconciliation report is generated.
+
+**AC-PAY-014**: Given a reconciliation discrepancy exceeds the configured threshold, when the discrepancy is detected, then an alert is sent to the finance team and an investigation ticket is created.
+
+### Gateway Failure Handling
+
+**AC-PAY-015**: Given the payment gateway is temporarily unavailable, when a contribution is attempted, then the system handles the failure gracefully (queues for retry or informs the donor to try later) without data loss or inconsistent state.
+
+**AC-PAY-016**: Given a webhook from the gateway is received, when the same webhook event has already been processed, then the duplicate is handled idempotently with no side effects.
+
+### Financial Reporting
+
+**AC-PAY-017**: Given an administrator with the appropriate role, when they access the financial dashboard, then they see accurate totals for: total raised, total disbursed, total interest disbursed, total in escrow, total refunded, and net platform position.
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| --- | --- | --- | --- |
+| March 2026 | 0.1 | — | Initial stub. |
+| March 2026 | 0.2 | — | Resolved OQ-1: Stripe selected as primary payment gateway. Updated tokenisation references to Stripe Elements. |
+| March 2026 | 0.3 | — | Resolved all remaining open questions: USD single currency (OQ-2), segregated escrow accounts (OQ-3), interest passed to campaign (OQ-4), milestone-based donor refund policy (OQ-5), no stored payment methods (OQ-6), tax-deductible entity (OQ-7), immediate capture (OQ-8). Simplified contribution states for immediate capture model. Added Section 8.5 donor-initiated refund policy. |

--- a/specs/product-vision-and-mission.md
+++ b/specs/product-vision-and-mission.md
@@ -1,0 +1,162 @@
+# MARS MISSION FUND
+
+## Product Vision & Mission
+
+Crowdfunding the Next Giant Leap
+
+The strategic foundation document for a secure crowdfunding platform that channels collective capital toward the missions, technologies, and teams taking humanity to Mars.
+
+---
+
+### Spec Ecosystem Context
+
+This is the L1 Strategic spec. It is the root document in the Mars Mission Fund specification hierarchy. All other specs inherit from and must align with the vision, mission, principles, and scope boundaries defined here. See `specs/README.md` for the full specification index.
+
+| Field | Value |
+|---|---|
+| SPEC ID | L1-001 |
+| DOCUMENT | Product Vision & Mission |
+| VERSION | 1.3 |
+| STATUS | Approved |
+| CLASSIFICATION | Internal |
+| RATE OF CHANGE | Slow — revised quarterly or at major strategic pivots |
+| DEPENDS ON | None (root document) |
+| DEPENDED ON BY | All L2, L3, and L4 specs |
+| DATE | March 2026 |
+
+---
+
+## 1. Product Vision
+
+### 1.1 Vision Statement
+
+Mars Mission Fund exists to become the world's most trusted platform for collectively funding humanity's journey to Mars — turning everyday investors into mission backers who power the engineering, science, and infrastructure that will make interplanetary life possible.
+
+### 1.2 The Problem We Solve
+
+Space exploration has historically been the domain of nation-states and a handful of billionaire-backed ventures. The result is a bottleneck: brilliant teams with viable Mars-enabling technologies struggle to find funding, while millions of people who care deeply about humanity's future have no meaningful way to contribute capital toward specific missions.
+
+Mars Mission Fund bridges this gap by creating a secure, transparent, and purpose-built crowdfunding platform exclusively focused on Mars-bound projects. We give capital a direction and give ambition a launchpad.
+
+### 1.3 Who We Serve
+
+| Persona | Description | Primary Need |
+|---|---|---|
+| Mission Backers | Individuals who want to fund specific Mars projects with as little as $50 | Transparency, trust, and a tangible connection to the mission they fund |
+| Project Creators | Engineers, scientists, and teams building Mars-enabling technology | A credible platform to raise capital, gain visibility, and prove viability |
+| Institutional Partners | Space agencies, research institutions, and corporate sponsors | Due diligence, compliance, and aggregated deal flow for strategic co-investment |
+| Platform Administrators | Internal team responsible for curation, compliance, and platform integrity | Efficient review workflows, robust access control, and audit trails |
+
+### 1.4 Strategic Principles
+
+- **Security as Foundation:** Every line of code, every workflow, every integration is built on a security-first architecture. In a financial platform, trust is not a feature — it is the product. See: `tech/security.md`
+- **Transparency as Currency:** Backers see exactly where their money goes. Projects report milestones publicly. The platform itself is auditable and explainable. See: `tech/audit.md`
+- **Accessibility Over Exclusivity:** A $50 contribution and a $50,000 institutional commitment both matter. The platform democratises access to space funding. See: `domain/donor.md`
+- **Curation Over Volume:** We are not a marketplace for everything. Every project is reviewed, vetted, and approved before going live. Quality over quantity. See: `domain/campaign.md`
+- **Bold but Responsible:** Our brand is bold and optimistic, but our financial systems are cautious and compliant. We speak like engineers who dream big and build carefully. See: `standards/brand.md`
+
+---
+
+## 2. Product Mission
+
+### 2.1 Mission Statement
+
+To build and operate a secure, regulation-ready crowdfunding platform that enables vetted Mars-mission projects to raise capital from a global community of backers — with institutional-grade security, transparent governance, and an experience that makes complex financial participation feel as immediate as a countdown to launch.
+
+### 2.2 Core Workflows
+
+The platform is organised around three core transactional workflows. Each is summarised here at the strategic level; detailed acceptance criteria, state machines, and interface contracts are defined in the corresponding domain specs.
+
+#### Workflow 1: Campaign Lifecycle
+
+*Detailed spec: `domain/campaign.md`*
+
+Project creators submit proposals containing mission objectives, team credentials, funding targets, milestone plans, and risk disclosures. Submissions enter a structured review pipeline managed by platform administrators. Approved projects become live campaigns with public funding pages, progress tracking, milestone verification, and completion or failure handling.
+
+- Creator registers, completes identity verification (KYC), and submits a project proposal via guided form.
+- Platform administrators with "Reviewer" role assess proposals against published curation criteria with full audit logging.
+- Approved projects transition to "Live" status with public campaign pages. Rejected proposals receive written rationale and resubmission guidance.
+- Live campaigns track funding progress, manage stretch goals, and enforce deadline rules.
+- Milestone verification triggers staged fund disbursement. Campaign completion or failure triggers appropriate settlement workflows.
+- All state transitions are immutable and timestamped for audit trail integrity.
+
+#### Workflow 2: Donor Lifecycle
+
+*Detailed specs: `domain/donor.md`, `domain/payments.md`, `domain/kyc.md`*
+
+The donor-side experience encompasses discovery, contribution, and ongoing relationship management. Backers find projects aligned with their interests, contribute through a secure payment flow, and maintain a long-term relationship with the missions they fund through impact reporting and engagement features.
+
+- Backers discover campaigns via search, recommendation algorithms, curated collections, and category browsing.
+- Contribution flow uses PCI DSS-compliant payment processing with tokenisation — the platform never stores raw card data.
+- Funds are held in escrow until predefined milestones are met and verified by administrators.
+- Backers receive milestone updates, impact reports, and mission progress notifications for projects they fund.
+- Contribution history, tax receipt generation, and cumulative impact dashboards maintain the ongoing donor relationship.
+- All financial transactions are encrypted in transit (TLS 1.3) and at rest (AES-256) with full reconciliation.
+
+#### Workflow 3: Account & Identity
+
+*Detailed specs: `domain/account.md`, `domain/kyc.md`, `tech/security.md`*
+
+The account bounded context governs the full lifecycle of a user's relationship with the platform: creation, authentication, profile management, role assignment, session management, and account recovery or deactivation. It underpins every interaction and enforces fine-grained permissions appropriate for a financial application.
+
+- Registration with email verification, strong password policy, and optional SSO via OAuth 2.0 / OpenID Connect.
+- Multi-factor authentication (TOTP, WebAuthn) required for all financial actions and administrative operations.
+- Role-based access control (RBAC) with defined roles: Backer, Creator, Reviewer, Administrator, and Super Administrator.
+- KYC verification workflow with document upload, automated checks, and manual review for edge cases.
+- Profile management includes notification preferences, contribution history, and downloadable tax receipts.
+- Account recovery, deactivation, and data portability handled in compliance with GDPR and Australian Privacy Act.
+
+---
+
+## 3. Scope Boundaries
+
+Clarity about scope is as important as ambition. These boundaries are authoritative — any spec that proposes features outside these boundaries must first update this document with an approved change request.
+
+### 3.1 What We Are
+
+- A secure crowdfunding platform exclusively for Mars-enabling projects.
+- A curated marketplace where every project is reviewed and approved before going live.
+- A transparent system where backers can track exactly how their contributions are used.
+- A regulation-ready platform designed to meet PCI DSS, GDPR, and Australian Privacy Act requirements.
+- An accessible platform where contributions from $50 to $50,000 are equally valued.
+
+### 3.2 What We Are Not
+
+- We are not a general crowdfunding platform. We exclusively fund Mars-enabling projects.
+- We are not an investment platform. Contributions are donations or pledges, not equity purchases, until regulatory frameworks evolve.
+- We are not a project incubator. We fund vetted projects; we do not originate or manage them.
+- We are not a social network. Community features serve transparency and accountability, not engagement metrics.
+- We are not a payment processor. We integrate with established payment gateways; we do not build our own.
+
+---
+
+## 4. Success Metrics
+
+The platform's success is measured across five dimensions. These metrics are owned by this document; individual specs may define supporting metrics that roll up into these.
+
+| Dimension | Key Metric | Year 1 Target |
+|---|---|---|
+| Trust | Zero data breaches; 100% uptime for financial flows | Maintain through launch + 12 months |
+| Adoption | Registered backers | 50,000 backers across 20+ countries |
+| Funding | Total capital raised through platform | $5M cumulative in first year |
+| Curation | Project success rate (milestones delivered on time) | > 80% of funded projects hit first milestone |
+| Security | Mean time to detect / respond to security events | MTTD < 15 min, MTTR < 4 hours |
+
+---
+
+## 5. Specification Ecosystem
+
+This document is the root of a four-layer specification hierarchy designed for agent-first consumption. Each layer has a distinct rate of change and scope of authority. The full index with cross-references and dependency metadata is maintained in `specs/README.md`.
+
+| Layer | Purpose | Documents | Rate of Change |
+|---|---|---|---|
+| L1 | Strategic vision and scope | `product-vision-and-mission.md` | Quarterly / pivots |
+| L2 | Standards and principles | `standards/brand.md`, `standards/engineering.md` | Monthly / standard reviews |
+| L3 | Technical how-we-build | `tech/architecture`, `security`, `reliability`, `data-management`, `frontend`, `audit`, `markdown`, `tech-stack` | Sprint-level / tech decisions |
+| L4 | Domain what-we-build | `domain/account`, `campaign`, `donor`, `payments`, `kyc` | Per feature / per release |
+
+**Agent protocol:** Before implementing any task, read `specs/README.md` to identify which specs govern the affected domain. Specs at lower layers must not contradict higher layers. If a conflict is detected, flag it as a blocking issue and reference both specs.
+
+---
+
+*Your stake. Their mission. Our planet.*

--- a/specs/standards/brand.md
+++ b/specs/standards/brand.md
@@ -1,0 +1,551 @@
+# Brand Application Standard
+
+> **Spec ID**: L2-001
+> **Version**: 1.2
+> **Status**: Approved
+> **Rate of Change**: Monthly / standard reviews
+> **Depends On**: L1-001 (Product Vision & Mission), Brand Guidelines (mars-mission-fund-brand.html)
+> **Depended On By**: L3-005 (tech/frontend.md), L4-001 (domain/account.md), L4-002 (domain/campaign.md), L4-003 (domain/donor.md)
+
+---
+
+## Purpose
+
+> **Local demo scope**: The token architecture, semantic mappings, and component specifications are **real** — they drive the local demo's UI implementation. Voice-in-product patterns guide all user-facing copy. Accessibility requirements apply fully. Logo placement and dark mode exception contexts (email, PDF) are theatre.
+
+This document defines how the Mars Mission Fund brand system is applied within the product. It translates the brand guidelines (the source of truth for visual identity) into actionable rules for product design and implementation.
+
+**This document does not duplicate the brand guidelines.** It specifies the two-tier token architecture, component-to-token mappings, voice-in-product patterns, and accessibility requirements. For design token values, logo usage rules, and visual specimens, reference the brand guidelines directly.
+
+**Source of truth for brand identity**: `mars-mission-fund-brand.html`
+
+---
+
+## Token Architecture
+
+The product uses a **two-tier token system**. This is the most important architectural decision in this spec.
+
+**Tier 1 — Identity Tokens**: Named for the brand vocabulary. Defined in the brand guidelines. These are the raw palette — colours, fonts, timing curves. They are **never referenced directly in component code**.
+
+**Tier 2 — Semantic Tokens**: Named for purpose and intent. Defined in this spec. These map to identity tokens and are the **only layer components are allowed to consume**.
+
+```text
+Component code → Semantic token → Identity token → Raw value
+
+Button background → --color-action-primary → --launchfire → #FF5C1A
+```
+
+**Why two tiers?**
+
+- If the brand evolves and "primary action" shifts from Launchfire to a different colour, one mapping changes — not every component.
+- Agents building UI reach for the semantic name matching their intent, not the brand vocabulary.
+- Misuse becomes structurally impossible: components cannot reference `--launchfire` directly, so a developer cannot accidentally use the primary action colour for an error state.
+
+**Rule**: Component code, stylesheets, and UI implementations must **only** reference Tier 2 semantic tokens. Direct references to Tier 1 identity tokens in component code are a spec violation.
+
+---
+
+## 1. Tier 1 — Identity Tokens (Brand Reference)
+
+These tokens are defined in the brand guidelines and reproduced here as a reference for the semantic mapping in Section 2. They form the brand's visual vocabulary. Do not reference these in component code.
+
+### 1.1 Colour Identity Tokens
+
+#### Deep Space — Foundation
+
+| Identity Token | Value | Brand Role |
+| --------------- | ------- | ----------- |
+| `--void` | `#060A14` | Deepest space, maximum contrast |
+| `--deep-space` | `#0B1628` | Dark foundation, secondary depth |
+| `--nebula` | `#0E2040` | Elevated dark, atmospheric depth |
+| `--orbit` | `#1A3A6E` | Mid-depth blue, structural emphasis |
+
+#### Launch Fire — Energy
+
+| Identity Token | Value | Brand Role |
+| --------------- | ------- | ----------- |
+| `--launchfire` | `#FF5C1A` | Primary brand energy, ignition point |
+| `--ignition` | `#FF8C42` | Secondary warmth, sustained energy |
+| `--afterburn` | `#FFB347` | Trailing warmth, gradient endpoint |
+| `--red-planet` | `#C1440E` | Mars surface, deep warmth |
+
+#### Metallic Silver — Trust & Finish
+
+| Identity Token | Value | Brand Role |
+| --------------- | ------- | ----------- |
+| `--chrome` | `#E8EDF5` | Brightest metallic, primary light |
+| `--silver` | `#C8D0DC` | Mid metallic, secondary light |
+| `--stardust` | `#8A96A8` | Muted metallic, tertiary light |
+| `--white` | `#F5F8FF` | Near-white, maximum light |
+
+#### Mission Outcomes
+
+| Identity Token | Value | Brand Role |
+| --------------- | ------- | ----------- |
+| `--success` | `#2FE8A2` | Mission complete green |
+| `--success-deep` | `#1AB878` | Deep success green, gradient endpoint |
+| `--signal-blue` | `#5B8FD8` | Communication indicator blue |
+
+### 1.2 Gradient Identity Tokens
+
+| Identity Token | Value |
+| --------------- | ------- |
+| `--grad-launch-sequence` | `linear-gradient(135deg, #FF5C1A, #FF8C42, #FFB347)` |
+| `--grad-deep-field` | `linear-gradient(135deg, #060A14, #0E2040, #1A3A6E)` |
+| `--grad-metallic-sheen` | `linear-gradient(135deg, #E8EDF5, #C8D0DC, #8A96A8)` |
+| `--grad-mars-atmosphere` | `linear-gradient(135deg, #C1440E, #FF5C1A, #FF8C42)` |
+| `--grad-night-launch` | `linear-gradient(135deg, #060A14 0%, #0B1628 50%, rgba(255,92,26,0.15) 100%)` |
+| `--grad-mission-success` | `linear-gradient(135deg, #0B1628, rgba(47,232,162,0.2), #0B1628)` |
+
+### 1.3 Typography Identity Tokens
+
+| Identity Token | Value | Brand Role |
+| --------------- | ------- | ----------- |
+| `--font-display` | Bebas Neue, sans-serif | Commanding display presence |
+| `--font-body` | DM Sans, sans-serif | Intelligent readability |
+| `--font-data` | Space Mono, monospace | Technical precision |
+
+### 1.4 Motion Identity Tokens
+
+| Identity Token | Value |
+| --------------- | ------- |
+| `--duration-fast` | 150ms |
+| `--duration-base` | 300ms |
+| `--duration-medium` | 500ms |
+| `--duration-slow` | 800ms |
+| `--easing-out` | `cubic-bezier(0.25, 1, 0.5, 1)` |
+| `--easing-spring` | `cubic-bezier(0.34, 1.56, 0.64, 1)` |
+
+### 1.5 Radius Identity Tokens
+
+| Identity Token | Value |
+| --------------- | ------- |
+| `--radius-sm` | 8px |
+| `--radius-md` | 12px |
+| `--radius-lg` | 16px |
+| `--radius-xl` | 20px |
+| `--radius-2xl` | 24px |
+| `--radius-full` | 100px |
+
+---
+
+## 2. Tier 2 — Semantic Tokens (Component Consumption Layer)
+
+These are the only tokens components may reference. Each maps to a Tier 1 identity token. When the brand evolves, these mappings change — component code does not.
+
+**Opacity convention**: Where a semantic token derives from an identity token at reduced opacity, it is written as `{identity-token} / {opacity%}` (e.g., `--launchfire / 35%`). At build time this resolves to the corresponding `rgba()` value.
+
+### 2.1 Colour — Actions
+
+| Semantic Token | Maps To | Usage |
+| --------------- | --------- | ------- |
+| `--color-action-primary` | `--launchfire` | Primary CTA backgrounds, interactive links |
+| `--color-action-primary-hover` | `--ignition` | Hover/focus state on primary actions |
+| `--color-action-primary-text` | `--white` | Text on primary action backgrounds |
+| `--color-action-primary-shadow` | `--launchfire / 35%` | Drop shadow on primary CTAs |
+| `--color-action-secondary-bg` | `--white / 6%` | Secondary button background |
+| `--color-action-secondary-text` | `--silver` | Secondary button text |
+| `--color-action-secondary-border` | `--white / 12%` | Secondary button border |
+| `--color-action-ghost-text` | `--ignition` | Ghost button text |
+| `--color-action-ghost-border` | `--launchfire / 30%` | Ghost button border |
+| `--color-action-disabled` | `--stardust` at 50% opacity | Inactive buttons, disabled inputs |
+
+### 2.2 Colour — Status
+
+| Semantic Token | Maps To | Usage |
+| --------------- | --------- | ------- |
+| `--color-status-success` | `--success` | Funded, milestone complete, transaction confirmed |
+| `--color-status-success-bg` | `--success / 12%` | Success badge/card background |
+| `--color-status-success-border` | `--success / 20%` | Success badge/card border |
+| `--color-status-error` | `--red-planet` | Validation errors, failed transactions, campaign failure |
+| `--color-status-warning` | `--afterburn` | Deadline approaching, campaign ending soon |
+| `--color-status-info` | `--orbit` | Neutral informational badges, help text |
+| `--color-status-active` | `--launchfire` | Live campaign indicator dot |
+| `--color-status-active-bg` | `--launchfire / 12%` | Active badge background |
+| `--color-status-active-border` | `--launchfire / 20%` | Active badge border |
+| `--color-status-new` | `--signal-blue` | New mission indicator dot |
+| `--color-status-new-bg` | `--orbit / 40%` | New mission badge background |
+| `--color-status-new-border` | `--orbit / 60%` | New mission badge border |
+
+### 2.3 Colour — Surfaces
+
+| Semantic Token | Maps To | Usage |
+| --------------- | --------- | ------- |
+| `--color-bg-page` | `--void` | Primary page background |
+| `--color-bg-surface` | `--deep-space` | Cards, modals, secondary panels |
+| `--color-bg-elevated` | `--nebula` | Hover states on cards, dropdowns, elevated surfaces |
+| `--color-bg-overlay` | `--void / 90%` | Modal overlays, navigation backdrop |
+| `--color-bg-input` | `--white / 4%` | Form input backgrounds |
+| `--color-bg-accent` | `--orbit` | Table headers, emphasis blocks |
+
+### 2.4 Colour — Text
+
+| Semantic Token | Maps To | Usage |
+| --------------- | --------- | ------- |
+| `--color-text-primary` | `--chrome` | Headlines, primary content on dark backgrounds |
+| `--color-text-secondary` | `--silver` | Body text, descriptions, secondary content |
+| `--color-text-tertiary` | `--stardust` | Metadata, timestamps, placeholders, labels |
+| `--color-text-accent` | `--launchfire` | Section labels, highlighted links (large text only — see Accessibility) |
+| `--color-text-on-action` | `--white` | Text on primary action backgrounds |
+| `--color-text-success` | `--success` | Positive financial indicators, funded text |
+| `--color-text-error` | `--red-planet` | Error messages, failed transaction text |
+| `--color-text-warning` | `--afterburn` | Urgency indicators, deadline text |
+
+**Rule**: Text hierarchy must follow `--color-text-primary` then `--color-text-secondary` then `--color-text-tertiary`. Never use tertiary for primary content or primary for metadata.
+
+### 2.5 Colour — Borders & Dividers
+
+| Semantic Token | Maps To | Usage |
+| --------------- | --------- | ------- |
+| `--color-border-subtle` | `--white / 6%` | Card borders, section dividers |
+| `--color-border-emphasis` | `--orbit` | Table borders, form input borders on focus |
+| `--color-border-input` | `--white / 10%` | Default form input borders |
+| `--color-border-accent` | `--launchfire` | Top accent bars on cards, active navigation |
+
+### 2.6 Colour — Progress & Data Visualisation
+
+| Semantic Token | Maps To | Usage |
+| --------------- | --------- | ------- |
+| `--color-progress-fill` | `linear-gradient(90deg, --launchfire, --afterburn)` | In-progress campaign bar fill |
+| `--color-progress-complete` | `linear-gradient(90deg, --success, --success-deep)` | Completed campaign bar fill |
+| `--color-progress-track` | `--white / 6%` | Progress bar background track |
+| `--color-progress-indicator` | `--afterburn` | Endpoint dot on progress bars |
+| `--color-data-positive` | `--success` | Upward trend, gain indicators |
+| `--color-data-neutral` | `--stardust` | Stable/neutral data points |
+
+### 2.7 Gradients — Semantic
+
+| Semantic Token | Maps To | Usage |
+| --------------- | --------- | ------- |
+| `--gradient-action-primary` | `--grad-launch-sequence` | Primary CTA button backgrounds |
+| `--gradient-surface-card` | `--grad-deep-field` | Card gradient backgrounds |
+| `--gradient-surface-stat` | `linear-gradient(135deg, --nebula, --deep-space)` | Stat card backgrounds |
+| `--gradient-hero` | `--grad-night-launch` | Landing page hero sections |
+| `--gradient-campaign-hero` | `--grad-mars-atmosphere` | Campaign hero backgrounds |
+| `--gradient-celebration` | `--grad-mission-success` | Funded campaign celebration state |
+| `--gradient-achievement` | `--grad-metallic-sheen` | Achievement badges, coin renders |
+
+### 2.8 Typography — Semantic
+
+| Semantic Token | Maps To | Size | Weight | Additional |
+| --------------- | --------- | ------ | -------- | ----------- |
+| `--type-hero` | `--font-display` | 96px | 400 | letter-spacing: 0.03em. Landing page hero only. |
+| `--type-page-title` | `--font-display` | 56px | 400 | letter-spacing: 0.04em |
+| `--type-section-heading` | `--font-display` | 40px | 400 | letter-spacing: 0.04em |
+| `--type-card-title` | `--font-body` | 24px | 700 | |
+| `--type-body` | `--font-body` | 16px | 400 | line-height: 1.7 |
+| `--type-body-small` | `--font-body` | 13px | 400 | line-height: 1.7 |
+| `--type-button` | `--font-body` | 14px | 600 | letter-spacing: 0.01em |
+| `--type-label` | `--font-data` | 11px | 400 | letter-spacing: 0.2em, uppercase |
+| `--type-section-label` | `--font-data` | 11px | 400 | letter-spacing: 0.3em, uppercase |
+| `--type-data` | `--font-data` | 14px | 400 | Mission codes, financial figures, timestamps |
+| `--type-stat-value` | `--font-display` | 40px | 400 | letter-spacing: 0.03em |
+| `--type-stat-value-compact` | `--font-display` | 28px | 400 | letter-spacing: 0.05em |
+| `--type-input-label` | `--font-data` | 12px | 600 | letter-spacing: 0.05em, uppercase |
+
+**Rule**: The type scale is a closed set. No intermediate sizes or custom font assignments. If a design requires a size not in this scale, it must be added to this spec before implementation.
+
+**Rule**: `--font-display` (Bebas Neue) is always uppercase. Never set it in mixed case or lowercase.
+
+### 2.9 Motion — Semantic
+
+| Semantic Token | Duration | Easing | Usage |
+| --------------- | ---------- | -------- | ------- |
+| `--motion-enter` | `--duration-base` | `--easing-out` | Default element entry, card reveals |
+| `--motion-enter-emphasis` | `--duration-medium` | `--easing-spring` | CTA appearing, modal entry, success confirmations |
+| `--motion-hover` | `--duration-fast` | `--easing-out` | Hover states, icon transitions, toggle switches |
+| `--motion-panel` | `--duration-medium` | `--easing-out` | Modals, drawers, panels opening/closing |
+| `--motion-page` | `--duration-slow` | `--easing-out` | Page transitions, celebration animations |
+| `--motion-ambient` | 2-4s | ease-in-out, infinite | Decorative float, hero background elements |
+| `--motion-urgency` | 1.5s | ease-in-out, infinite | Live countdowns, deadline pulse glow |
+
+**Rule**: All animations must use these semantic tokens. No custom timing or easing values. All animation must be disableable via `prefers-reduced-motion` — see Accessibility section.
+
+### 2.10 Layout — Semantic
+
+| Semantic Token | Maps To | Usage |
+| --------------- | --------- | ------- |
+| `--radius-button` | `--radius-full` | All button variants |
+| `--radius-badge` | `--radius-sm` | Status badges, tags |
+| `--radius-input` | `--radius-md` | Form inputs |
+| `--radius-card` | `--radius-xl` | Standard UI cards |
+| `--radius-card-large` | `--radius-2xl` | Feature cards, logo cards |
+| `--radius-stat` | `--radius-lg` | Stat blocks, swatches |
+| `--radius-progress` | `--radius-full` | Progress bar tracks and fills |
+
+---
+
+## 3. Component Specifications
+
+This section defines how semantic tokens apply to specific product components. These mappings are mandatory — agents implementing UI must follow them exactly.
+
+### 3.1 Buttons
+
+| Variant | Background | Text | Border | Shadow | Usage |
+| --------- | ----------- | ------ | -------- | -------- | ------- |
+| Primary | `--gradient-action-primary` | `--color-action-primary-text` | none | `--color-action-primary-shadow` | Single primary action per viewport |
+| Secondary | `--color-action-secondary-bg` | `--color-action-secondary-text` | `--color-action-secondary-border` | none | Alternative actions |
+| Ghost | transparent | `--color-action-ghost-text` | `--color-action-ghost-border` | none | Tertiary actions |
+| Success | `--color-status-success-bg` | `--color-status-success` | `--color-status-success-border` | none | Post-success state |
+
+All buttons: `--radius-button`, `--type-button`, padding 12px 24px.
+
+**Rule**: Only one primary CTA per viewport.
+
+### 3.2 Cards
+
+| Element | Semantic Token |
+| --------- | --------------- |
+| Background | `--color-bg-surface` |
+| Border | `--color-border-subtle` |
+| Border radius | `--radius-card` |
+| Top accent bar | `2px --color-border-accent` gradient to `--color-status-warning` |
+| Padding | 32px |
+
+### 3.3 Progress Bars
+
+| Element | Semantic Token |
+| --------- | --------------- |
+| Track background | `--color-progress-track` |
+| Fill (in progress) | `--color-progress-fill` |
+| Fill (complete) | `--color-progress-complete` |
+| Track radius | `--radius-progress` |
+| Height | 8px |
+| Endpoint indicator | 14px circle, `--color-progress-indicator`, `box-shadow: 0 0 12px` |
+
+### 3.4 Stat Cards
+
+| Element | Semantic Token |
+| --------- | --------------- |
+| Background | `--gradient-surface-stat` |
+| Border | `--color-border-subtle` |
+| Border radius | `--radius-stat` |
+| Label | `--type-body-small` weight 500, `--color-text-tertiary` |
+| Value | `--type-stat-value`, `--color-text-primary` |
+| Sub text (positive) | `--type-body-small`, `--color-data-positive` |
+| Sub text (neutral) | `--type-body-small`, `--color-data-neutral` |
+
+### 3.5 Badges
+
+| Variant | Background | Text | Border | Dot |
+| --------- | ----------- | ------ | -------- | ----- |
+| Funded | `--color-status-success-bg` | `--color-status-success` | `--color-status-success-border` | `--color-status-success` |
+| Live / Active | `--color-status-active-bg` | `--color-action-primary-hover` | `--color-status-active-border` | `--color-status-active` |
+| New Mission | `--color-status-new-bg` | `--color-text-secondary` | `--color-status-new-border` | `--color-status-new` |
+
+All badges: `--radius-badge`, `--type-button` at 12px, padding 6px 12px, 6px dot indicator.
+
+### 3.6 Form Inputs
+
+| Element | Semantic Token |
+| --------- | --------------- |
+| Background | `--color-bg-input` |
+| Border (default) | `--color-border-input` |
+| Border (focus) | `--color-border-emphasis` |
+| Border radius | `--radius-input` |
+| Text | `--color-text-primary` |
+| Placeholder | `--color-text-tertiary` |
+| Label | `--type-input-label`, `--color-text-tertiary` |
+| Suffix/unit | `--type-data` at 12px, `--color-text-tertiary` |
+| Padding | 14px 48px 14px 16px |
+
+### 3.7 Section Labels
+
+| Element | Semantic Token |
+| --------- | --------------- |
+| Font | `--type-section-label` |
+| Colour | `--color-text-accent` |
+| Format | "NUMBER — TITLE" (e.g., "01 — Identity") |
+| Margin bottom | 16px |
+
+---
+
+## 4. Voice-in-Product
+
+The brand guidelines define the overall voice. This section specifies how that voice is applied to specific product surfaces. Agents generating copy or UI text must follow these patterns.
+
+### 4.1 Brand Personality Axes (Product Calibration)
+
+| Axis | Position | Product Implication |
+| ------ | ---------- | ------------------- |
+| Playful / Serious | 40% toward playful | Use mission metaphors and energising language, but never joke about money or risk |
+| Technical / Accessible | 65% toward accessible | Use precise financial and technical terms where required, but always explain in context |
+| Cautious / Bold | 80% toward bold | Lead with confidence and urgency, but every financial claim must be accurate |
+| Formal / Human | 70% toward human | Direct, warm, first-person plural ("we", "your"). Never corporate or legalistic in user-facing copy |
+
+### 4.2 Copy Patterns by Surface
+
+#### Campaign Pages
+
+| Element | Pattern | Example |
+| --------- | --------- | --------- |
+| Campaign title | Active verb + specific objective | "Building Pressurised Habitats for the First Mars Crews" |
+| Funding status | Percentage + time urgency | "73% funded — 18 days left to join the mission" |
+| CTA button | Direct action, no "click here" | "Back This Mission" |
+| Contribution prompt | Personal impact framing | "Every $50 moves the launch window closer" |
+
+#### Financial Confirmations
+
+| Element | Pattern | Example |
+| --------- | --------- | --------- |
+| Contribution confirmed | Precise amount + mission reference | "Your $250 is locked in. You're backing Mission MMF-2026-0147." |
+| Escrow notification | Status + reassurance | "Funds secured in escrow. Release on milestone verification." |
+| Disbursement notice | Action + transparency | "Milestone 2 verified. $840,000 released to Project Habitat Alpha." |
+
+#### Error States
+
+| Element | Pattern | Example |
+| --------- | --------- | --------- |
+| Payment failure | Helpful, not alarming | "We couldn't process this right now. Your data is safe — let's try again." |
+| Validation error | Specific, actionable | "Mission code format: MMF-2026-XXXX. Check the last four digits." |
+| System error | Honest, with next step | "Something went wrong on our end. We're looking into it. Try again in a few minutes." |
+
+#### Empty States
+
+| Element | Pattern | Example |
+| --------- | --------- | --------- |
+| No contributions yet | Invitation, not absence | "Your mission log is empty. Find a mission to back." |
+| No search results | Redirect, not dead end | "No missions match that search. Browse active campaigns instead." |
+| No milestones | Progress framing | "Milestones will appear here as the team hits targets." |
+
+### 4.3 Forbidden Language Patterns
+
+Never use the following in any user-facing product copy:
+
+| Pattern | Reason | Use Instead |
+| --------- | -------- | ------------- |
+| "Click here" | Non-descriptive, inaccessible | Descriptive link text: "View mission details" |
+| "Exciting opportunity" | Sounds like financial spam | Specific claim: "Funding closes in 18 days" |
+| "Synergistic", "disruptive", "revolutionary" | Corporate buzzwords violate brand voice | Plain language: specific, concrete descriptions |
+| "Investment" (without legal caveat) | Regulatory risk — contributions are not equity | "Contribution", "backing", "stake", "pledge" |
+| "Guaranteed returns" | Illegal in most jurisdictions | Never imply financial returns |
+| "Click to learn more" | Passive, vague | Action-specific: "Read the mission plan" |
+| Passive voice in CTAs | Weakens urgency | Active voice: "Back this mission" not "This mission can be backed" |
+
+---
+
+## 5. Accessibility Requirements
+
+The dark-first UI and high-contrast accent palette create specific accessibility challenges that must be addressed in every component.
+
+### 5.1 Colour Contrast
+
+| Text Context | Minimum Ratio | Token Pairing |
+| ------------- | -------------- | --------------- |
+| Primary text on page bg | 7:1 (AAA) | `--color-text-primary` on `--color-bg-page` = 14.8:1 |
+| Primary text on surface bg | 7:1 (AAA) | `--color-text-primary` on `--color-bg-surface` = 12.6:1 |
+| Secondary text on page bg | 4.5:1 (AA) | `--color-text-secondary` on `--color-bg-page` = 10.7:1 |
+| Tertiary text on page bg | 4.5:1 (AA) | `--color-text-tertiary` on `--color-bg-page` = 5.4:1 |
+| Accent text on page bg | 4.5:1 (AA large) | `--color-text-accent` on `--color-bg-page` = 4.8:1 |
+| Success text on page bg | 4.5:1 (AA) | `--color-text-success` on `--color-bg-page` = 10.1:1 |
+
+**Rule**: `--color-text-accent` must only be used at 18px+ bold or 24px+ regular (WCAG large text). For smaller accent text, use `--color-action-primary-hover` which provides higher contrast.
+
+**Rule**: `--color-text-tertiary` passes AA but fails AAA. Approved for metadata only — never for body text or interactive element labels.
+
+### 5.2 Motion Accessibility
+
+**Rule**: All animations must respect `prefers-reduced-motion: reduce`. When active:
+
+| Semantic Token | Normal Behaviour | Reduced Motion |
+| --------------- | ----------------- | ---------------- |
+| `--motion-enter` | Slide-in settle | Instant appearance |
+| `--motion-enter-emphasis` | Overshoot bounce | Fade-in at `--duration-fast` |
+| `--motion-ambient` | Continuous float | Static position |
+| `--motion-urgency` | Pulse glow | Static glow at 50% |
+| Progress bar fill | Animated fill | Instant fill |
+
+### 5.3 Focus States
+
+All interactive elements must have a visible focus indicator meeting WCAG 2.1 AA:
+
+| Element | Focus Style |
+| --------- | ------------ |
+| Buttons | `outline: 2px solid --color-action-primary-hover; outline-offset: 2px` |
+| Form inputs | `border-color: --color-action-primary; box-shadow: 0 0 0 3px rgba(255,92,26,0.25)` |
+| Links | `outline: 2px solid --color-action-primary-hover; outline-offset: 2px` |
+| Cards (interactive) | `border-color: --color-action-primary; box-shadow: 0 0 0 3px rgba(255,92,26,0.15)` |
+
+**Rule**: Focus styles must never be suppressed with `outline: none` without an equivalent visible alternative.
+
+### 5.4 Screen Reader Requirements
+
+| Context | Requirement |
+| --------- | ------------ |
+| Progress bars | `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, `aria-label` with campaign name and percentage |
+| Badge indicators | Dots are decorative (`aria-hidden="true"`); status via text |
+| Stat cards | Values and labels associated via `aria-labelledby` |
+| Button icons | Decorative: `aria-hidden="true"`. Icon-only: `aria-label` required |
+| Financial amounts | Screen reader includes currency: "$3,108,400 US dollars raised" |
+
+---
+
+## 6. Logo Usage in Product
+
+The brand guidelines are the source of truth for logo specifications. This section defines product-specific usage rules only.
+
+### 6.1 Logo Placement
+
+| Context | Variant | Size |
+| --------- | --------- | ------ |
+| Navigation bar | Coin icon mark only | 32px height |
+| Login / registration | Full vertical lockup (dark) | 120px coin, full wordmark |
+| Footer | Horizontal lockup | 72px coin, inline wordmark |
+| Favicon | Coin icon, simplified (no orbital ring) | 16px |
+| App icon | Coin on gradient background | Per platform guidelines |
+| Email header | Horizontal lockup | 48px coin height |
+
+### 6.2 Clear Space in Product
+
+Minimum clear space around the logo equals the height of the "M" in the wordmark. In constrained navigation contexts, the coin icon mark at 32px requires minimum 8px clear space on all sides.
+
+---
+
+## 7. Dark Mode / Light Mode
+
+### 7.1 Position
+
+Mars Mission Fund is a dark-first product. The deep-space palette is the primary UI context. There is no light mode for the core application.
+
+### 7.2 Exceptions
+
+| Context | Treatment |
+| --------- | ----------- |
+| Email templates | Light background for compatibility. `--color-bg-accent` headings, `--color-bg-page` body text on white. |
+| PDF exports / print | White background. `--color-bg-accent` headings, `--color-bg-page` body, `--color-action-primary` accents. |
+| Embedded widgets | Both dark and light variants. Light uses `--color-text-primary` background, `--color-bg-accent` text. |
+| Legal / compliance | Light background permitted if required by legal review. |
+
+**Note**: These exception contexts invert the standard dark-first token mappings. When implemented as components, they should define theme-specific semantic token overrides (e.g., a `light` theme map) rather than hardcoding values.
+
+---
+
+## 8. Brand Misuse in Product
+
+The following are violations of this standard. Agents and developers must flag these in code review.
+
+| Violation | Why It Matters |
+| ----------- | --------------- |
+| Referencing Tier 1 identity tokens in component code | Breaks the semantic abstraction; brand evolution requires component changes |
+| Using `--color-action-primary` for error states | Conflates actions with errors; confuses clickability |
+| Using `--color-status-success` for non-financial positives | Dilutes "funded" and "complete" meaning |
+| `--font-display` in body text or form labels | Display-only font; unreadable at small sizes |
+| Custom colours outside the token system | Breaks consistency, unmaintainable |
+| Animations ignoring `prefers-reduced-motion` | WCAG 2.1 SC 2.3.3 violation |
+| Multiple primary CTAs per viewport | Dilutes action hierarchy |
+| Corporate buzzwords in copy | Brand voice violation; see Forbidden Language Patterns |
+| Suppressed focus indicators | WCAG 2.1 SC 2.4.7 violation |
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| ------ | --------- | -------- | --------- |
+| March 2026 | 1.0 | — | Initial draft. Combined identity and semantic tokens. |
+| March 2026 | 1.1 | — | Restructured to two-tier token architecture. Identity tokens (Tier 1) for brand reference only; semantic tokens (Tier 2) as sole component consumption layer. Added semantic mappings for all colour, typography, motion, and layout tokens. Tier 1 direct reference added as misuse violation. |
+| March 2026 | 1.2 | — | Closed token chain gaps: replaced raw rgba/hex values in Tier 2 with identity token derivations using `{token} / {opacity%}` convention. Added `--success-deep` and `--signal-blue` to Tier 1. Removed unused `--crater`. Section 7.2 now references semantic tokens with note on light-theme overrides. |
+
+---
+
+*This standard governs brand application in the Mars Mission Fund product. For the visual identity source of truth (logo specimens, colour swatches, type specimens, motion demos), reference the brand guidelines: `mars-mission-fund-brand.html`.*

--- a/specs/standards/engineering.md
+++ b/specs/standards/engineering.md
@@ -1,0 +1,623 @@
+# Engineering Standard
+
+> **Spec ID**: L2-002
+> **Version**: 1.0
+> **Status**: Approved
+> **Rate of Change**: Monthly / standard reviews
+> **Depends On**: L1-001 (Product Vision & Mission)
+> **Depended On By**: L3-001 (tech/architecture.md), L3-002 (tech/security.md), L3-003 (tech/reliability.md), L3-004 (tech/data-management.md), L3-005 (tech/frontend.md), L3-006 (tech/audit.md), L3-007 (tech/markdown.md), L3-008 (tech/tech-stack.md), L4-004 (domain/payments.md), L4-005 (domain/kyc.md)
+
+---
+
+## Purpose
+
+> **Local demo scope**: Engineering values, quality gates, testing standards, and API contract rules are **real** — they govern the local demo code. Multi-team dynamics, bar-raiser reviews, on-call expectations, and cross-team resource allocation are theatre for the workshop setting. The security invariants apply to all code written for the demo.
+
+This document is the engineering constitution for Mars Mission Fund.
+It defines the non-negotiable constraints that every L3 and L4 spec inherits, and the values that give those constraints meaning.
+
+The litmus test for whether a rule belongs here: **would violating it be a fundamental engineering failure regardless of which feature, service, or domain it occurs in?**
+If yes, it's in this document.
+If it only applies in certain contexts, it belongs in an L3 or L4 spec.
+
+Detailed implementation guidance — specific technology choices, architecture patterns, threat models, frontend frameworks — lives in the L3 specs that depend on this document.
+This standard defines the playing field.
+L3 and L4 specs play on it.
+
+---
+
+## 0. Our Engineering Values
+
+Engineering decisions at Mars Mission Fund are guided by six value positions.
+These are not aspirations — they are trade-offs we have deliberately chosen, with consequences we accept.
+Each position sits on a spectrum of valid alternatives; we've chosen the position that fits our context as a security-critical financial platform with a small, high-trust team building a product-first experience.
+
+These value positions were identified using the [Campbell Method Engineering Values Assessment](https://www.campbellmethod.com/resources/engineering-values-assessment), a framework for mapping engineering culture across six fundamental spectrums.
+
+### 0.1 Product First — Experience Obsession
+
+**Spectrum**: [Company Primary Focus](https://www.campbellmethod.com/resources/engineering-values-assessment/spectrums/focus) — ranges from Technology First (breakthrough invention) through Product First and Customer Obsessed to Market Focused (competitive edge).
+
+**Our position**: Product First.
+The total user experience is the primary source of value.
+The product's elegance, simplicity, integration, and feel are paramount.
+Design has a seat at the table.
+"Good enough" is never approved for user-facing surfaces.
+
+**What this means for engineering**: Design review has veto power on UI implementations.
+Prototype testing is required before full implementation of experience-critical features.
+Internal APIs serving user-facing flows receive the same care as external ones.
+
+**Trade-offs we accept**: We may be slower to iterate.
+We may dismiss valid feedback that conflicts with the product vision.
+We invest more in fit and finish than competitors who ship faster.
+
+### 0.2 Don't Reinvent — Smart Assembly
+
+**Spectrum**: [Execution & Build Strategy](https://www.campbellmethod.com/resources/engineering-values-assessment/spectrums/execution) — ranges from Full Control (own the full stack) through Invent & Simplify and Don't Reinvent to Buy, Don't Build (integrate solutions).
+
+**Our position**: Don't Reinvent.
+Our engineering time is precious and should only be spent on our competitive advantage.
+We use best-of-breed open-source and managed services for everything that isn't core to what makes Mars Mission Fund unique.
+We are not a technology vendor — we don't invent new infrastructure.
+But we are an engineering organisation, not a systems integrator.
+
+**What this means for engineering**: Heavy reliance on high-quality open-source and cloud-native managed services.
+The key decision is which tool to use, not whether to build it.
+Build-vs-buy reviews default to buy unless there is a defined trigger demanding innovation (see Section 2).
+
+**Trade-offs we accept**: Vendor lock-in.
+Dependency on external roadmaps and pricing.
+Limited differentiation on infrastructure.
+We build on the same foundations as competitors — our differentiation is in the product layer, not the platform layer.
+
+### 0.3 Empowered Autonomy — Trust Experts
+
+**Spectrum**: [Decision-Making Pace](https://www.campbellmethod.com/resources/engineering-values-assessment/spectrums/pace) — ranges from Analyse & Deliberate (measure twice, cut once) through Seek Consensus and Empowered Autonomy to Bias for Action (ship and learn).
+
+**Our position**: Empowered Autonomy.
+The person closest to the problem is best equipped to solve it.
+Leadership sets context and goals (the what and why); teams own the how.
+Minimal approval chains.
+Clear ownership structures.
+We hire smart people and trust their judgement — within the boundaries this standard defines.
+
+**What this means for engineering**: Small, autonomous teams with full ownership.
+Decisions pushed down to where the information is.
+The standards in this document provide the high support that matches our high expectations.
+If you think a standard is wrong, challenge it through a change request — don't ignore it.
+
+**Trade-offs we accept**: Potential inconsistency across teams.
+Duplicated effort.
+This model requires an extremely high and consistent hiring bar — it fails with mediocre teams.
+
+### 0.4 High Standards — Standards Force Invention
+
+**Spectrum**: [Quality and Standards](https://www.campbellmethod.com/resources/engineering-values-assessment/spectrums/quality) — ranges from Meticulous Craft (quality is the product) through High Standards and Pragmatic Quality to Ship and Iterate (learn from production).
+
+**Our position**: High Standards.
+High standards are a forcing function to invent.
+The goal isn't perfectionism — it's using constraints to force the team to find simpler, more scalable solutions.
+When a standard feels like it's blocking you, that's the signal to find a better approach, not to lower the bar.
+Leaders constantly raise the bar and reject work that doesn't meet it.
+Rework cycles are expected and budgeted, not failures.
+
+**What this means for engineering**: Bar-raiser reviews on every significant PR.
+Standards applied to everything: code, documents, specs, meeting preparation.
+The standard is often "is this scalable to 100x?" and "is this the simplest solution?"
+Mediocrity is not tolerated.
+"Good enough" is rejected.
+
+**Trade-offs we accept**: A culture that can feel sharp-edged.
+Burnout risk if the bar always feels impossibly high.
+The possibility of getting stuck if the team can't find the inventive solution.
+We mitigate these through our Coach & Support leadership model.
+
+### 0.5 Selfless — Company Over Team
+
+**Spectrum**: [Collaboration Model](https://www.campbellmethod.com/resources/engineering-values-assessment/spectrums/collaboration) — ranges from Internal Competition (compete to innovate) through Siloed Autonomy and Selfless to One-Team (succeed together).
+
+**Our position**: Selfless.
+Do what is best for the company, not your team or yourself.
+Best-for-the-company wins every argument.
+Engineers give candid feedback on other teams' work.
+Managers give their best engineer to higher-priority projects when needed.
+Resources flow to where the company needs them, not where teams want to keep them.
+
+**What this means for engineering**: Cross-team contributions to shared infrastructure are expected, not optional.
+If another team needs your service modified for a company-priority feature, that takes precedence over your team's roadmap.
+No empire-building.
+No knowledge hoarding.
+Success is defined as "the company won."
+
+**Trade-offs we accept**: Difficult to measure and reward individual team performance.
+May inadvertently reward weak managers by taking resources from strong teams.
+Requires high maturity and psychological safety to execute without resentment.
+
+### 0.6 Coach & Support — Develop People
+
+**Spectrum**: [Leadership Model](https://www.campbellmethod.com/resources/engineering-values-assessment/spectrums/leadership) — ranges from Dive Deep & Audit (trust but verify) through Coach & Support and Empower & Delegate to Provide Cover (shield the team).
+
+**Our position**: Coach & Support.
+A manager's job is to make their team members successful.
+Leaders are facilitators, career guides, and performance coaches.
+One-on-ones focus on growth, well-being, and removing blockers.
+Psychological safety is non-negotiable.
+Learning from failure is how we improve.
+
+**What this means for engineering**: Code review is teaching, not gatekeeping.
+We leave things in a better condition than we found them — every PR, every spec, every architectural decision should make the next person's (or agent's) job easier.
+This principle manifests as clear naming, thorough documentation, explicit cross-references in specs, and choosing the option that's more legible to newcomers.
+
+**Trade-offs we accept**: May be slower for short-term results.
+Doesn't work well for low performers who need directive management.
+Requires leaders who are both technically strong and skilled coaches.
+
+### Value Coherence
+
+These six positions form a reinforcing system:
+
+- *Empowered Autonomy* requires *High Standards* — you can only trust experts to decide independently if the standards are clear enough that "independent" doesn't mean "inconsistent."
+- *Don't Reinvent* supports *Selfless* — when teams use the same best-of-breed tools, knowledge transfers naturally and people move across teams without relearning infrastructure.
+- *Coach & Support* sustains *High Standards* — you can maintain a high bar without creating a harsh culture because leaders develop people rather than just gatekeeping.
+- *Product First* drives *High Standards* — experience obsession means the quality bar is set by user perception, not engineering convenience.
+- *Selfless* enables *Empowered Autonomy* — teams can make fast local decisions because shared values ensure those decisions align with company direction.
+
+---
+
+## 1. Security Invariants
+
+**Values served**: High Standards, Product First
+
+On a financial platform, security is not a feature — it is the product.
+These invariants are absolute.
+No exception process exists for violating them.
+If a design cannot satisfy these constraints, the design is wrong.
+
+Detailed threat models, control matrices, and compliance mappings live in `tech/security.md`.
+This section defines the invariants that `tech/security.md` must implement and that all other specs must respect.
+
+### 1.1 Encryption
+
+All data is encrypted in transit using TLS 1.3 (minimum).
+No exceptions for internal service-to-service communication.
+
+All sensitive data is encrypted at rest using AES-256.
+"Sensitive" is defined in the data classification scheme in `tech/data-management.md`, but at minimum includes: personal identifiable information, financial data, authentication credentials, and KYC documents.
+
+### 1.2 Data Access
+
+All database queries use parameterised queries or prepared statements.
+String concatenation in SQL or query construction is prohibited under all circumstances — including scripts, migrations, and one-off administrative tasks.
+
+Raw SQL is never written in application code.
+All data access goes through a data access layer that enforces parameterisation, logging, and access control.
+
+### 1.3 Secrets Management
+
+Secrets (API keys, database credentials, encryption keys, signing certificates) are never stored in source code, configuration files committed to version control, log output, error messages, or client-side code.
+
+All secrets are managed through a dedicated secrets management service and injected via environment variables at runtime.
+The specific service is defined in `tech/architecture.md`.
+
+### 1.4 Input Validation
+
+All external input is validated, sanitised, and type-checked at the system boundary before any processing.
+"External" means: user input, API requests, webhook payloads, file uploads, URL parameters, and any data originating outside the trust boundary.
+
+Content Security Policy (CSP) headers are mandatory on all web responses.
+The specific policy is defined in `tech/security.md`.
+
+File uploads are validated for type, size, and content.
+Uploaded files are never served from the same domain as the application.
+
+### 1.5 Authentication & Authorisation
+
+Every API endpoint and every service-to-service call is authenticated and authorised.
+There are no anonymous internal endpoints.
+"It's only called by our own services" is not a security model.
+
+Multi-factor authentication is required for all financial actions and all administrative operations.
+The MFA implementation (TOTP, WebAuthn) is defined in `tech/security.md`.
+
+### 1.6 Dependency Security
+
+Every dependency (direct and transitive) is scanned for known vulnerabilities on every build.
+Critical CVEs (CVSS 9.0+) must be patched or mitigated within 24 hours of disclosure.
+High CVEs (CVSS 7.0–8.9) within 7 days.
+
+No dependency may be added without a review of its licence, maintenance status, and security history.
+Abandoned packages (no commits in 12 months, no maintainer response to issues) are not permitted.
+
+### 1.7 Logging & Auditability
+
+Every state mutation in the system is logged with a timestamp, actor identity, action performed, and affected resource.
+Logs are append-only and immutable.
+No mechanism exists to delete or modify audit log entries.
+
+Sensitive data is never logged.
+Log entries use resource identifiers, not raw personal data.
+
+The full audit logging architecture is defined in `tech/audit.md`.
+This invariant establishes that audit logging is not optional for any service or domain.
+
+---
+
+## 2. Build vs. Own
+
+**Values served**: Don't Reinvent, High Standards
+
+Engineering time is spent on what makes Mars Mission Fund unique.
+For everything else, we use best-of-breed tools and accept the trade-offs that come with external dependencies.
+
+### 2.1 Decision Framework
+
+Every significant technology decision must pass through this framework.
+"Significant" means: introducing a new service, library, or infrastructure component; building functionality that could be replaced by an existing solution; or replacing an existing tool.
+
+| Question | If Yes | If No |
+| ---------- | -------- | ------- |
+| Is this capability core to our competitive advantage — the product experience, campaign curation, or donor relationship that differentiates MMF? | Evaluate building. Proceed to build-quality assessment. | Default to integrate or buy. |
+| Does an open-source or SaaS solution exist that solves ≥80% of the requirement? | Use it. Engineer the remaining 20% as integration, not reimplementation. | Evaluate building. Document why the market gap exists. |
+| Does integrating the third-party solution expand our PCI DSS scope or introduce an unacceptable trust boundary? | This is a valid trigger to build. Document the security rationale. | Integrate. |
+| Does the external solution's roadmap, pricing model, or licence create an existential risk to the platform? | Evaluate alternatives first. If none exist, build with an abstraction layer. | Integrate. |
+| Can we wrap the external solution behind an interface that allows replacement without changing consuming code? | Required for all integrations. Proceed. | Design the abstraction layer before integrating. |
+
+### 2.2 What We Build
+
+The competitive advantage of Mars Mission Fund lives in: the campaign curation and review pipeline, the donor matching and impact reporting experience, the product experience layer, and the trust and transparency mechanisms that differentiate us from generic crowdfunding.
+Engineering time is concentrated here.
+
+### 2.3 What We Don't Build
+
+We do not build: payment processing (integrate Stripe/Adyen), identity verification infrastructure (integrate a KYC provider), email delivery, search infrastructure, hosting/compute, CI/CD pipelines, monitoring/alerting platforms, or any other capability where mature, well-maintained solutions exist.
+We configure, integrate, and operate these — we don't reinvent them.
+
+### 2.4 Abstraction Requirement
+
+Every external dependency must be accessed through an internal interface (adapter, gateway, or service wrapper) that the rest of the codebase consumes.
+No application code should reference a vendor SDK directly.
+This allows replacement of the underlying provider without changing consuming code.
+
+### 2.5 Vendor Evaluation Criteria
+
+When selecting between external solutions, evaluate in this priority order:
+
+1. **Security posture** — Does it meet our security invariants? Does it narrow or widen our compliance scope?
+1. **Fitness for purpose** — Does it solve the actual problem, not an adjacent one?
+1. **Operational maturity** — Active maintenance, responsive to CVEs, clear deprecation policy, transparent incident history.
+1. **Integration surface** — Clean API, good documentation, supports our abstraction requirement.
+1. **Community and ecosystem** — Healthy contributor base, ecosystem of plugins/extensions, low risk of abandonment.
+1. **Total cost of ownership** — Licensing, integration engineering, ongoing maintenance, migration cost if we leave.
+
+---
+
+## 3. Ownership & Decision Authority
+
+**Values served**: Empowered Autonomy, Selfless
+
+The person closest to the problem decides — within the boundaries this standard defines.
+Decisions are pushed down to where the information is.
+But autonomy operates in service of the company, not the team.
+
+### 3.1 Decision Rights
+
+| Decision Type | Authority | Escalation |
+| -------------- | ----------- | ----------- |
+| Implementation approach within a spec | Engineer who owns the work | None required |
+| Technology selection within the Build vs. Own framework | Team that will operate the technology | Peer review from one engineer outside the team |
+| API contract changes affecting other teams | Owning team, with mandatory notification to consuming teams | If consuming teams object, resolve at engineering leadership level |
+| New external dependency introduction | Team lead, with vendor evaluation documented | Security review required for dependencies that handle sensitive data |
+| Architectural decisions affecting multiple services | Owning team proposes, architecture review validates | Defined in `tech/architecture.md` (ADR process) |
+| Changes to this standard (L2) | Engineering leadership | Requires review of all L3 specs for alignment |
+
+### 3.2 Autonomy Within Standards
+
+Engineers are free to make any technical decision that does not violate a standard defined in this document or the L3/L4 specs governing their domain.
+This freedom is the point — the standards exist to make autonomy safe, not to constrain creativity.
+
+If an engineer believes a standard is wrong, the correct response is to propose a change request to the standard — not to ignore it.
+Standards evolve.
+Ignoring them erodes the trust that makes autonomy possible.
+
+### 3.3 Company Over Team
+
+When team priorities conflict with company priorities, company priorities win.
+Specifically:
+
+- If a company-priority feature requires modifications to your team's service, that work takes precedence over your team's roadmap.
+  Negotiate timeline, not whether.
+- Contributions to shared infrastructure, libraries, and platform capabilities are expected of every team.
+  This is not optional good citizenship — it is part of the job.
+- Knowledge hoarding is a values violation.
+  Documentation, clear interfaces, and cross-team legibility are not overhead — they are how Selfless operates in practice.
+- When architectural disagreements arise between teams, the resolution criterion is "what is best for Mars Mission Fund," not "what is best for my team."
+
+### 3.4 Code Review & Approval
+
+Every change requires at least one approving review before merge.
+The reviewer must be someone other than the author.
+
+For changes affecting security surfaces (authentication, authorisation, payment flows, data access, encryption), a second reviewer with domain expertise in security is required.
+
+Reviews are teaching opportunities, not gatekeeping checkpoints.
+Reviewers explain the "why" behind requested changes.
+Authors explain the "why" behind their approach.
+The goal is shared understanding, not compliance.
+
+Bar-raiser principle: at least one reviewer on every significant PR actively asks "is this the simplest solution?" and "would this scale to 100x?"
+Accepting mediocre work is a High Standards violation.
+
+---
+
+## 4. Quality Gates
+
+**Values served**: High Standards, Coach & Support
+
+These gates apply to every line of code, every spec, every deployment.
+They are not bureaucratic overhead — they are the forcing function that drives invention.
+When a gate blocks you, the correct response is to find a better approach, not to request an exemption.
+
+Rework cycles are expected and budgeted.
+Rejecting work that doesn't meet the bar is normal, not adversarial.
+The Coach & Support leadership model ensures this happens with respect and growth orientation.
+
+### 4.1 Code Quality
+
+All code must pass automated linting and formatting checks before review.
+The specific rulesets are defined per language in `tech/architecture.md`, but the principle is: formatting is never a review discussion.
+Automate it.
+
+All code must be type-safe.
+Dynamic typing is permitted only where the language requires it.
+Where type systems are available, they are mandatory and configured at their strictest practical level.
+
+### 4.2 Test Coverage
+
+All new code must include tests.
+The minimum coverage thresholds are:
+
+| Layer | Minimum Coverage | Type |
+| ------- | ----------------- | ------ |
+| Business logic / domain | 90% | Unit tests |
+| API endpoints | 100% of documented contracts | Integration tests |
+| Payment flows | 100% of success and failure paths | Integration + end-to-end |
+| Authentication / authorisation | 100% of roles and permission combinations | Integration tests |
+| UI components | 80% | Unit + snapshot tests |
+
+Coverage is measured on new and changed code, not retroactively applied to legacy code.
+Legacy code coverage is improved incrementally — every PR that touches legacy code must leave test coverage higher than it found it.
+
+### 4.3 The "Better Than We Found It" Rule
+
+Every PR must leave the codebase in a better state than the author found it.
+This is the Coach & Support value made concrete.
+It manifests as:
+
+- Improved naming or documentation in code you touched, even if your PR is about something else.
+- Updated or added comments explaining non-obvious decisions.
+- Removal of dead code, unused imports, or stale TODOs encountered during the work.
+- Spec cross-references added where they were missing.
+
+This is a review criterion.
+Reviewers should ask: "does this PR leave things better for the next person?"
+
+### 4.4 Pre-Merge Checklist
+
+Every PR must satisfy these gates before merge.
+CI enforces what it can; reviewers enforce the rest.
+
+| Gate | Enforced By | Applies To |
+| ------ | ------------ | ----------- |
+| All tests pass | CI (automated) | All PRs |
+| Lint and format clean | CI (automated) | All PRs |
+| Type checks pass | CI (automated) | All PRs |
+| Dependency vulnerability scan clean | CI (automated) | All PRs |
+| Test coverage thresholds met | CI (automated) | All PRs |
+| At least one approving review | Git platform | All PRs |
+| Security reviewer approved | Git platform + process | Security-surface PRs |
+| No secrets in code or config | CI (automated, secret scanning) | All PRs |
+| "Better than we found it" check | Reviewer (manual) | All PRs |
+| Spec alignment verified | Reviewer (manual) | PRs implementing spec requirements |
+
+### 4.5 Deployment Gates
+
+No deployment without a rollback plan.
+Every deployment must document: what is being deployed, how to verify it's working, and how to roll back within 15 minutes if it isn't.
+
+Feature flags are the default deployment mechanism for user-facing changes.
+Ship dark, verify, enable incrementally.
+The feature flag framework is defined in `tech/architecture.md`.
+
+Production deployments to financial flows (payment processing, escrow, disbursement) require a second approval from an engineer who did not author the change.
+
+---
+
+## 5. API & Interface Contracts
+
+**Values served**: High Standards, Product First
+
+Every interface is a product surface.
+Internal APIs receive the same care as external ones — because today's internal API is tomorrow's integration point, and because *Product First* means the developer experience of consuming an API is part of the overall experience we obsess over.
+
+### 5.1 Versioning
+
+All APIs are versioned from day one.
+The versioning scheme (URL path, header, or content negotiation) is defined in `tech/architecture.md`.
+This standard requires that a scheme exists and is applied consistently.
+
+Breaking changes require a new version.
+The previous version must continue to function for a defined deprecation period (minimum 90 days for external APIs, minimum 30 days for internal APIs).
+
+### 5.2 Backward Compatibility
+
+Within a version, changes must be backward compatible.
+Specifically:
+
+- New fields may be added to responses.
+- New optional parameters may be added to requests.
+- Existing fields must not be removed, renamed, or have their type changed.
+- Existing behaviour must not change for the same inputs.
+
+If a change cannot satisfy these constraints, it requires a new version.
+
+### 5.3 Error Response Contract
+
+All APIs must use a consistent error response format.
+The specific format is defined in `tech/architecture.md`, but must include:
+
+- A machine-readable error code (not just an HTTP status code).
+- A human-readable message suitable for display (respecting the voice-in-product patterns from `standards/brand.md`).
+- A correlation ID linking the error to the request trace.
+- Sufficient context for the caller to understand what went wrong and how to fix it, without leaking internal implementation details or sensitive data.
+
+### 5.4 Authentication
+
+Every API endpoint (internal and external) requires authentication.
+The authentication mechanism is defined in `tech/security.md`.
+This standard establishes that unauthenticated endpoints do not exist in the Mars Mission Fund system, with the sole exception of the health check endpoint required by `tech/reliability.md`.
+
+### 5.5 Documentation
+
+Every API must have machine-readable documentation (OpenAPI/Swagger or equivalent) that is generated from or validated against the actual implementation.
+Documentation that can drift from the implementation is not documentation — it is a liability.
+
+---
+
+## 6. Observability Baseline
+
+**Values served**: High Standards, Empowered Autonomy
+
+Empowered Autonomy creates a specific need for strong observability.
+When teams make independent decisions, the consequences of those decisions must be visible system-wide.
+Observability is not optional — it is how we make autonomy accountable.
+
+The full audit logging architecture is defined in `tech/audit.md`.
+The alerting and incident response architecture is defined in `tech/reliability.md`.
+This section defines the baseline that every service must meet.
+
+### 6.1 Structured Logging
+
+All services emit structured logs (JSON format).
+Every log entry must include:
+
+| Field | Description |
+| ------- | ------------ |
+| `timestamp` | ISO 8601 with timezone |
+| `level` | Standard levels: DEBUG, INFO, WARN, ERROR |
+| `correlation_id` | Unique ID that follows a request across all services it touches |
+| `service` | Name of the emitting service |
+| `message` | Human-readable description of the event |
+| `context` | Structured metadata relevant to the event (resource IDs, action type, duration) |
+
+Sensitive data (PII, financial data, credentials) must never appear in log entries.
+Use resource identifiers, not raw data.
+
+### 6.2 Correlation IDs
+
+Every request entering the system is assigned a unique correlation ID at the edge.
+This ID propagates through every service-to-service call, every database query, every external API call, and every log entry.
+A single correlation ID must be sufficient to reconstruct the complete request path across all services.
+
+### 6.3 Health Checks
+
+Every service exposes a health check endpoint that reports:
+
+- **Liveness**: "this process is running and can accept requests."
+- **Readiness**: "this service and its critical dependencies are functioning correctly."
+
+Health checks are the one exception to the "every endpoint requires authentication" rule.
+They must be accessible to the orchestration layer without credentials.
+
+### 6.4 Metrics
+
+Every service emits metrics for:
+
+| Metric | Description |
+| -------- | ------------ |
+| Request rate | Requests per second, by endpoint and status code |
+| Error rate | Errors per second, by endpoint and error type |
+| Latency | p50, p95, p99 response times, by endpoint |
+| Saturation | Resource utilisation (CPU, memory, connections, queue depth) |
+
+These are the four golden signals.
+Additional domain-specific metrics are defined in the relevant L3 and L4 specs.
+
+### 6.5 Alerting Baseline
+
+Every service must define alerts for:
+
+- Error rate exceeding baseline by 2x for 5 minutes.
+- p99 latency exceeding SLA threshold for 5 minutes.
+- Health check failures for 3 consecutive checks.
+- Dependency health check failures.
+
+Alert thresholds and escalation policies are defined in `tech/reliability.md`.
+This standard establishes that alerting is not optional for any service.
+
+---
+
+## 7. Environment & Configuration
+
+**Values served**: Don't Reinvent, High Standards
+
+We use standard infrastructure tooling.
+We don't build custom deployment pipelines when established ones exist.
+Configuration is explicit, environment-aware, and never hardcoded.
+
+### 7.1 Environment Parity
+
+Development, staging, and production environments must be structurally identical.
+Same services, same network topology, same configuration shape.
+The only differences are: scale (fewer replicas in dev), data (synthetic data in non-production), and secrets (different credentials per environment).
+
+"Works on my machine" is not an acceptable state.
+If it doesn't work in the CI environment, it doesn't work.
+
+### 7.2 Configuration
+
+All runtime configuration is provided via environment variables.
+No configuration is hardcoded in application code or committed to version control (except for default values in development).
+
+Feature flags are managed through a dedicated feature flag service.
+They are not environment variables — they are runtime-configurable without deployment.
+The specific service is defined in `tech/architecture.md`.
+
+### 7.3 Secrets
+
+Secrets are injected at runtime from a secrets management service.
+They are never:
+
+- Committed to version control (even in encrypted form in application repositories).
+- Passed as command-line arguments (visible in process listings).
+- Written to disk (except by the secrets management agent itself).
+- Logged, even at DEBUG level.
+
+Secret rotation must be possible without application redeployment.
+The application must handle secret rotation gracefully (re-read on expiry, not crash).
+
+### 7.4 Deployments
+
+Every deployment is automated.
+No manual steps between "merge to main" and "running in production" except explicit approval gates defined in Section 4.5.
+
+Every deployment is reproducible.
+Given the same commit hash and configuration, the deployment produces identical artefacts.
+
+Every deployment is reversible.
+Rollback to the previous version must be possible within 15 minutes with no data loss.
+If a change includes a database migration, the migration must be backward-compatible (the previous application version must function against the new schema).
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| ------ | --------- | -------- | --------- |
+| March 2026 | 1.0 | — | Initial draft. Engineering values (six spectrum positions from Campbell Method Engineering Values Assessment), security invariants, build-vs-own framework, ownership and decision authority, quality gates, API contract standards, observability baseline, environment and configuration. |
+
+---
+
+*This standard governs all engineering at Mars Mission Fund.
+Every L3 and L4 spec inherits these constraints.
+For the value framework that informs these standards, see the [Campbell Method Engineering Values Assessment](https://www.campbellmethod.com/resources/engineering-values-assessment).*

--- a/specs/standards/mars-mission-fund-brand.html
+++ b/specs/standards/mars-mission-fund-brand.html
@@ -1,0 +1,1760 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mars Mission Fund — Brand Guidelines</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=DM+Sans:wght@300;400;500;600&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --void: #060A14;
+    --deep-space: #0B1628;
+    --nebula: #0E2040;
+    --orbit: #1A3A6E;
+    --launchfire: #FF5C1A;
+    --ignition: #FF8C42;
+    --afterburn: #FFB347;
+    --success: #2FE8A2;
+    --silver: #C8D0DC;
+    --chrome: #E8EDF5;
+    --stardust: #8A96A8;
+    --white: #F5F8FF;
+    --red-planet: #C1440E;
+    --crater: #8B3A2A;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    background: var(--void);
+    color: var(--white);
+    font-family: 'DM Sans', sans-serif;
+    overflow-x: hidden;
+  }
+
+  /* STAR FIELD */
+  .starfield {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    overflow: hidden;
+  }
+  .star {
+    position: absolute;
+    background: white;
+    border-radius: 50%;
+    animation: twinkle var(--d, 3s) ease-in-out infinite alternate;
+    opacity: var(--o, 0.6);
+  }
+  @keyframes twinkle { from { opacity: var(--o, 0.6); } to { opacity: 0.1; } }
+
+  /* LAYOUT */
+  .page { position: relative; z-index: 1; }
+
+  /* COVER */
+  .cover {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    padding: 80px 40px;
+    position: relative;
+    overflow: hidden;
+  }
+  .cover::before {
+    content: '';
+    position: absolute;
+    width: 900px; height: 900px;
+    background: radial-gradient(ellipse, rgba(255,92,26,0.12) 0%, transparent 65%);
+    top: 50%; left: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+  }
+  .cover-inner { max-width: 900px; }
+
+  .brand-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255,92,26,0.12);
+    border: 1px solid rgba(255,92,26,0.3);
+    border-radius: 100px;
+    padding: 6px 18px;
+    font-family: 'Space Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.15em;
+    color: var(--ignition);
+    margin-bottom: 48px;
+    text-transform: uppercase;
+  }
+  .brand-badge::before {
+    content: '';
+    width: 6px; height: 6px;
+    background: var(--launchfire);
+    border-radius: 50%;
+    animation: pulse 2s ease-in-out infinite;
+  }
+  @keyframes pulse { 0%,100% { transform: scale(1); opacity:1; } 50% { transform:scale(1.5); opacity:0.5; } }
+
+  .cover h1 {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: clamp(72px, 12vw, 160px);
+    line-height: 0.9;
+    letter-spacing: 0.02em;
+    background: linear-gradient(135deg, var(--chrome) 0%, var(--silver) 30%, var(--launchfire) 60%, var(--afterburn) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 16px;
+  }
+  .cover-subtitle {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: clamp(28px, 4vw, 52px);
+    letter-spacing: 0.25em;
+    color: var(--stardust);
+    margin-bottom: 32px;
+  }
+  .cover-desc {
+    font-size: 16px;
+    line-height: 1.7;
+    color: var(--silver);
+    max-width: 520px;
+    margin: 0 auto 64px;
+    font-weight: 300;
+  }
+
+  .doc-meta {
+    display: flex;
+    gap: 40px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .meta-item { text-align: center; }
+  .meta-label {
+    font-family: 'Space Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    color: var(--stardust);
+    text-transform: uppercase;
+    margin-bottom: 4px;
+  }
+  .meta-value {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--silver);
+  }
+
+  /* SECTION */
+  section {
+    padding: 120px 40px;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  .section-label {
+    font-family: 'Space Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.3em;
+    color: var(--launchfire);
+    text-transform: uppercase;
+    margin-bottom: 16px;
+  }
+  .section-title {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: clamp(48px, 6vw, 88px);
+    letter-spacing: 0.03em;
+    line-height: 1;
+    margin-bottom: 24px;
+  }
+  .section-title span { color: var(--launchfire); }
+  .section-intro {
+    font-size: 16px;
+    line-height: 1.75;
+    color: var(--stardust);
+    max-width: 600px;
+    margin-bottom: 80px;
+    font-weight: 300;
+  }
+
+  .divider {
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(255,92,26,0.3), transparent);
+    margin: 0 40px;
+  }
+
+  /* LOGO SECTION */
+  .logo-showcase {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+    margin-bottom: 64px;
+  }
+  @media(max-width:768px){ .logo-showcase { grid-template-columns:1fr; } }
+
+  .logo-card {
+    border-radius: 24px;
+    padding: 60px 40px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+    position: relative;
+    overflow: hidden;
+  }
+  .logo-card.dark {
+    background: var(--deep-space);
+    border: 1px solid rgba(255,255,255,0.06);
+  }
+  .logo-card.light {
+    background: var(--chrome);
+  }
+  .logo-card.fire {
+    background: linear-gradient(135deg, var(--red-planet), var(--launchfire), var(--afterburn));
+  }
+  .logo-card.space {
+    background: linear-gradient(135deg, var(--void), var(--nebula));
+    border: 1px solid rgba(255,92,26,0.2);
+  }
+
+  /* SVG LOGO */
+  .mmf-logo { display: flex; flex-direction: column; align-items: center; gap: 20px; }
+
+  .coin-svg { width: 120px; height: 120px; }
+
+  .logo-wordmark {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+  }
+  .wordmark-main {
+    font-family: 'Bebas Neue', sans-serif;
+    letter-spacing: 0.12em;
+    font-size: 32px;
+    line-height: 1;
+  }
+  .wordmark-sub {
+    font-family: 'Space Mono', monospace;
+    font-size: 9px;
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    opacity: 0.7;
+  }
+
+  .logo-label {
+    font-family: 'Space Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    opacity: 0.5;
+  }
+
+  /* ICON ONLY */
+  .icon-grid {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    margin-top: 32px;
+  }
+  .icon-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+  .icon-bg {
+    width: 80px; height: 80px;
+    border-radius: 20px;
+    display: grid;
+    place-items: center;
+  }
+  .icon-bg.dark { background: var(--deep-space); border: 1px solid rgba(255,255,255,0.08); }
+  .icon-bg.light { background: var(--chrome); }
+  .icon-bg.grad { background: linear-gradient(135deg, var(--red-planet), var(--ignition)); }
+  .icon-label { font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 0.2em; color: var(--stardust); text-transform: uppercase; }
+
+  /* COLOR PALETTE */
+  .palette-group { margin-bottom: 56px; }
+  .palette-group-title {
+    font-family: 'Space Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.2em;
+    color: var(--stardust);
+    text-transform: uppercase;
+    margin-bottom: 20px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+  }
+  .palette-row { display: flex; gap: 16px; flex-wrap: wrap; }
+
+  .swatch {
+    flex: 1;
+    min-width: 140px;
+    border-radius: 16px;
+    overflow: hidden;
+    cursor: default;
+    transition: transform 0.2s ease;
+  }
+  .swatch:hover { transform: translateY(-4px); }
+  .swatch-color { height: 96px; position: relative; }
+  .swatch-color::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to bottom, rgba(255,255,255,0.08), transparent);
+  }
+  .swatch-info {
+    background: var(--deep-space);
+    padding: 14px 16px;
+    border: 1px solid rgba(255,255,255,0.06);
+    border-top: none;
+    border-radius: 0 0 16px 16px;
+  }
+  .swatch-name { font-weight: 600; font-size: 13px; margin-bottom: 4px; }
+  .swatch-hex { font-family: 'Space Mono', monospace; font-size: 11px; color: var(--stardust); }
+  .swatch-use { font-size: 11px; color: var(--stardust); margin-top: 6px; line-height: 1.4; }
+
+  .swatch-primary { background: var(--void); }
+  .swatch-deep { background: var(--deep-space); }
+  .swatch-nebula { background: var(--nebula); }
+  .swatch-orbit { background: var(--orbit); }
+  .swatch-launch { background: var(--launchfire); }
+  .swatch-ignition { background: var(--ignition); }
+  .swatch-afterburn { background: var(--afterburn); }
+  .swatch-success { background: var(--success); }
+  .swatch-silver { background: var(--silver); }
+  .swatch-chrome { background: var(--chrome); }
+  .swatch-stardust { background: var(--stardust); }
+  .swatch-mars { background: var(--red-planet); }
+
+  /* GRADIENT SHOWCASE */
+  .gradient-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 32px; }
+  @media(max-width:768px){ .gradient-row { grid-template-columns:1fr; } }
+
+  .grad-card {
+    border-radius: 16px;
+    overflow: hidden;
+  }
+  .grad-swatch { height: 72px; }
+  .grad-info {
+    background: var(--deep-space);
+    padding: 14px 16px;
+    border: 1px solid rgba(255,255,255,0.06);
+    border-top: none;
+    border-radius: 0 0 16px 16px;
+  }
+  .grad-name { font-weight: 600; font-size: 13px; margin-bottom: 4px; }
+  .grad-value { font-family: 'Space Mono', monospace; font-size: 10px; color: var(--stardust); }
+  .grad-use { font-size: 11px; color: var(--stardust); margin-top: 6px; }
+
+  /* TYPOGRAPHY */
+  .type-specimen { margin-bottom: 64px; }
+
+  .font-card {
+    background: var(--deep-space);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 24px;
+    padding: 48px;
+    margin-bottom: 24px;
+    overflow: hidden;
+    position: relative;
+  }
+  .font-card::before {
+    content: attr(data-font);
+    position: absolute;
+    top: -20px; right: 40px;
+    font-family: 'Space Mono', monospace;
+    font-size: 120px;
+    opacity: 0.03;
+    color: white;
+    pointer-events: none;
+    letter-spacing: -0.05em;
+  }
+  .font-meta {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 32px;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+  .font-name-block {}
+  .font-role {
+    font-family: 'Space Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.25em;
+    color: var(--launchfire);
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .font-name { font-weight: 700; font-size: 18px; }
+  .font-source { font-size: 12px; color: var(--stardust); margin-top: 4px; }
+
+  .font-tags { display: flex; gap: 8px; flex-wrap: wrap; align-items: flex-start; }
+  .tag {
+    background: rgba(255,92,26,0.1);
+    border: 1px solid rgba(255,92,26,0.2);
+    border-radius: 100px;
+    padding: 4px 12px;
+    font-family: 'Space Mono', monospace;
+    font-size: 10px;
+    color: var(--ignition);
+    letter-spacing: 0.05em;
+  }
+  .tag.blue {
+    background: rgba(26,58,110,0.3);
+    border-color: rgba(26,58,110,0.6);
+    color: var(--silver);
+  }
+  .tag.green {
+    background: rgba(47,232,162,0.1);
+    border-color: rgba(47,232,162,0.2);
+    color: var(--success);
+  }
+
+  .type-specimen-text {
+    border-top: 1px solid rgba(255,255,255,0.06);
+    padding-top: 32px;
+  }
+  .specimen-display {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: clamp(48px, 7vw, 96px);
+    line-height: 1;
+    letter-spacing: 0.03em;
+    background: linear-gradient(135deg, var(--chrome), var(--silver));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 12px;
+  }
+  .specimen-alpha {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 22px;
+    letter-spacing: 0.15em;
+    color: var(--stardust);
+    margin-bottom: 8px;
+  }
+  .specimen-nums {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 18px;
+    letter-spacing: 0.1em;
+    color: var(--orbit);
+  }
+
+  .specimen-body { font-size: 16px; line-height: 1.8; color: var(--silver); margin-bottom: 12px; }
+  .specimen-body-sm { font-size: 13px; line-height: 1.7; color: var(--stardust); }
+
+  .specimen-mono {
+    font-family: 'Space Mono', monospace;
+    font-size: 14px;
+    color: var(--success);
+    line-height: 1.6;
+  }
+
+  .type-scale {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 48px;
+  }
+  .scale-row {
+    display: flex;
+    align-items: baseline;
+    gap: 24px;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+    padding-bottom: 16px;
+  }
+  .scale-label {
+    font-family: 'Space Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    color: var(--stardust);
+    min-width: 80px;
+    text-transform: uppercase;
+  }
+  .scale-example { color: var(--white); }
+
+  /* UI SAMPLES */
+  .ui-samples { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  @media(max-width:768px){ .ui-samples { grid-template-columns: 1fr; } }
+
+  .ui-card {
+    background: var(--deep-space);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 20px;
+    padding: 32px;
+    position: relative;
+    overflow: hidden;
+  }
+  .ui-card::after {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, var(--launchfire), var(--afterburn));
+  }
+
+  /* BUTTON STYLES */
+  .btn-row { display: flex; gap: 12px; flex-wrap: wrap; }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: 100px;
+    padding: 12px 24px;
+    font-size: 14px;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    font-family: 'DM Sans', sans-serif;
+    letter-spacing: 0.01em;
+    transition: all 0.2s ease;
+    position: relative;
+    overflow: hidden;
+  }
+  .btn-primary {
+    background: linear-gradient(135deg, var(--launchfire), var(--ignition));
+    color: white;
+    box-shadow: 0 8px 24px rgba(255,92,26,0.35);
+  }
+  .btn-secondary {
+    background: rgba(255,255,255,0.06);
+    color: var(--silver);
+    border: 1px solid rgba(255,255,255,0.12);
+  }
+  .btn-ghost {
+    background: transparent;
+    color: var(--ignition);
+    border: 1px solid rgba(255,92,26,0.3);
+  }
+  .btn-success {
+    background: linear-gradient(135deg, rgba(47,232,162,0.15), rgba(47,232,162,0.05));
+    color: var(--success);
+    border: 1px solid rgba(47,232,162,0.25);
+  }
+  .btn-icon { width: 16px; height: 16px; }
+
+  /* STAT CARD */
+  .stat-card {
+    background: linear-gradient(135deg, var(--nebula), var(--deep-space));
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 16px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .stat-label { font-size: 12px; color: var(--stardust); font-weight: 500; }
+  .stat-value { font-family: 'Bebas Neue', sans-serif; font-size: 40px; letter-spacing: 0.03em; color: var(--chrome); line-height: 1; }
+  .stat-sub { font-size: 12px; color: var(--success); display: flex; align-items: center; gap: 4px; }
+
+  .stat-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+
+  /* PROGRESS BAR */
+  .progress-block { margin-top: 20px; }
+  .progress-header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 10px; }
+  .progress-title { font-size: 14px; font-weight: 600; }
+  .progress-pct { font-family: 'Bebas Neue', sans-serif; font-size: 20px; color: var(--launchfire); letter-spacing: 0.05em; }
+  .progress-bar { height: 8px; background: rgba(255,255,255,0.06); border-radius: 100px; overflow: hidden; }
+  .progress-fill { height: 100%; border-radius: 100px; background: linear-gradient(90deg, var(--launchfire), var(--afterburn)); position: relative; }
+  .progress-fill::after {
+    content: '';
+    position: absolute;
+    right: 0; top: 50%;
+    width: 14px; height: 14px;
+    transform: translate(50%, -50%);
+    background: var(--afterburn);
+    border-radius: 50%;
+    box-shadow: 0 0 12px var(--afterburn);
+  }
+
+  /* INPUT */
+  .input-block { margin-top: 24px; }
+  .input-label { font-size: 12px; font-weight: 600; color: var(--stardust); margin-bottom: 8px; letter-spacing: 0.05em; text-transform: uppercase; font-family: 'Space Mono', monospace; }
+  .input-wrap { position: relative; }
+  .input-field {
+    width: 100%;
+    background: rgba(255,255,255,0.04);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 12px;
+    padding: 14px 48px 14px 16px;
+    font-size: 15px;
+    color: var(--white);
+    font-family: 'DM Sans', sans-serif;
+    outline: none;
+  }
+  .input-suffix {
+    position: absolute;
+    right: 14px; top: 50%;
+    transform: translateY(-50%);
+    font-family: 'Space Mono', monospace;
+    font-size: 12px;
+    color: var(--stardust);
+  }
+
+  /* BADGE SAMPLES */
+  .badge-row { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 8px;
+    padding: 6px 12px;
+    font-size: 12px;
+    font-weight: 600;
+  }
+  .badge-funded { background: rgba(47,232,162,0.12); color: var(--success); border: 1px solid rgba(47,232,162,0.2); }
+  .badge-active { background: rgba(255,92,26,0.12); color: var(--ignition); border: 1px solid rgba(255,92,26,0.2); }
+  .badge-new { background: rgba(26,58,110,0.4); color: var(--silver); border: 1px solid rgba(26,58,110,0.6); }
+  .badge-dot { width: 6px; height: 6px; border-radius: 50%; }
+  .badge-dot.green { background: var(--success); }
+  .badge-dot.orange { background: var(--launchfire); }
+  .badge-dot.blue { background: #5B8FD8; }
+
+  /* ICON SYSTEM */
+  .icon-system { margin-top: 20px; }
+  .icon-row-display { display: flex; gap: 16px; flex-wrap: wrap; }
+  .icon-display {
+    width: 48px; height: 48px;
+    background: rgba(255,255,255,0.04);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    color: var(--silver);
+  }
+  .icon-display.active {
+    background: rgba(255,92,26,0.12);
+    border-color: rgba(255,92,26,0.25);
+    color: var(--launchfire);
+  }
+
+  /* VOICE & TONE */
+  .voice-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  @media(max-width:768px){ .voice-grid { grid-template-columns:1fr; } }
+
+  .voice-card {
+    border-radius: 20px;
+    padding: 32px;
+    border: 1px solid rgba(255,255,255,0.06);
+  }
+  .voice-card.do { background: rgba(47,232,162,0.04); border-color: rgba(47,232,162,0.15); }
+  .voice-card.dont { background: rgba(255,92,26,0.04); border-color: rgba(255,92,26,0.15); }
+  .voice-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 20px;
+    font-weight: 700;
+    font-size: 15px;
+  }
+  .voice-header.do { color: var(--success); }
+  .voice-header.dont { color: var(--launchfire); }
+  .voice-icon { font-size: 20px; }
+  .voice-examples { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+  .voice-examples li {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--silver);
+    padding-left: 16px;
+    position: relative;
+  }
+  .voice-examples li::before {
+    content: '"';
+    position: absolute;
+    left: 0;
+    color: var(--stardust);
+  }
+
+  /* MOTION */
+  .motion-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-top: 32px; }
+  @media(max-width:768px){ .motion-row { grid-template-columns: 1fr 1fr; } }
+
+  .motion-card {
+    background: var(--deep-space);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 16px;
+    padding: 24px 20px;
+    text-align: center;
+  }
+  .motion-vis {
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 16px;
+  }
+  .motion-dot {
+    width: 16px; height: 16px;
+    background: var(--launchfire);
+    border-radius: 50%;
+  }
+  .m-ease-out .motion-dot { animation: easeOut 2s cubic-bezier(0.25,1,0.5,1) infinite; }
+  .m-spring .motion-dot { animation: spring 2s cubic-bezier(0.34,1.56,0.64,1) infinite; }
+  .m-float .motion-dot { animation: float 3s ease-in-out infinite; }
+  .m-ignite .motion-dot { animation: ignite 1.5s ease-in-out infinite; background: var(--afterburn); }
+
+  @keyframes easeOut { 0%,100% { transform: translateX(-20px); } 50% { transform: translateX(20px); } }
+  @keyframes spring { 0% { transform: scale(0.7); } 60% { transform: scale(1.2); } 100% { transform: scale(1); } }
+  @keyframes float { 0%,100% { transform: translateY(6px); } 50% { transform: translateY(-6px); } }
+  @keyframes ignite { 0%,100% { transform: scale(1); box-shadow: 0 0 8px var(--launchfire); } 50% { transform: scale(1.3); box-shadow: 0 0 20px var(--launchfire), 0 0 40px rgba(255,92,26,0.4); } }
+
+  .motion-name { font-weight: 700; font-size: 13px; margin-bottom: 6px; }
+  .motion-spec { font-family: 'Space Mono', monospace; font-size: 10px; color: var(--stardust); }
+
+  /* FOOTER */
+  .brand-footer {
+    border-top: 1px solid rgba(255,255,255,0.06);
+    padding: 80px 40px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    max-width: 1200px;
+    margin: 0 auto;
+    flex-wrap: gap;
+    gap: 32px;
+    flex-wrap: wrap;
+  }
+  .footer-brand { font-family: 'Bebas Neue', sans-serif; font-size: 32px; letter-spacing: 0.1em; }
+  .footer-brand span { color: var(--launchfire); }
+  .footer-note { font-family: 'Space Mono', monospace; font-size: 11px; color: var(--stardust); letter-spacing: 0.1em; }
+
+  /* UTILITIES */
+  .mt-8 { margin-top: 8px; }
+  .mt-16 { margin-top: 16px; }
+  .mt-24 { margin-top: 24px; }
+  .mt-32 { margin-top: 32px; }
+  .mt-48 { margin-top: 48px; }
+  .mt-64 { margin-top: 64px; }
+
+  /* NAV */
+  .toc {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: rgba(6,10,20,0.9);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+    padding: 0 40px;
+    display: flex;
+    align-items: center;
+    gap: 0;
+    overflow-x: auto;
+  }
+  .toc a {
+    display: block;
+    padding: 16px 20px;
+    font-family: 'Space Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--stardust);
+    text-decoration: none;
+    white-space: nowrap;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s;
+  }
+  .toc a:hover { color: var(--white); border-bottom-color: var(--launchfire); }
+  .toc-brand {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 20px;
+    letter-spacing: 0.1em;
+    color: var(--launchfire);
+    margin-right: 24px;
+    padding: 16px 0;
+    white-space: nowrap;
+    border-right: 1px solid rgba(255,255,255,0.08);
+    padding-right: 24px;
+  }
+
+  /* CLEARSPACE */
+  .clearspace-demo {
+    background: var(--deep-space);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 20px;
+    padding: 48px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    position: relative;
+  }
+  .clearspace-inner {
+    position: relative;
+    padding: 32px;
+  }
+  .clearspace-inner::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border: 1.5px dashed rgba(255,92,26,0.3);
+    border-radius: 8px;
+    pointer-events: none;
+  }
+  .clearspace-label { font-family: 'Space Mono', monospace; font-size: 10px; color: var(--launchfire); letter-spacing: 0.2em; text-transform: uppercase; opacity: 0.7; }
+
+  .dont-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; margin-top: 32px; }
+  @media(max-width:768px) { .dont-grid { grid-template-columns:1fr; } }
+  .dont-card {
+    background: var(--deep-space);
+    border: 1px solid rgba(255,60,60,0.15);
+    border-radius: 16px;
+    padding: 24px;
+    text-align: center;
+  }
+  .dont-logo-area {
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 16px;
+    border-radius: 12px;
+    background: rgba(255,255,255,0.02);
+    position: relative;
+  }
+  .dont-logo-area::after {
+    content: '✕';
+    position: absolute;
+    top: 8px; right: 8px;
+    color: rgba(255,60,60,0.6);
+    font-size: 14px;
+    font-weight: 700;
+  }
+  .dont-title { font-size: 13px; font-weight: 700; color: rgba(255,100,100,0.8); margin-bottom: 4px; }
+  .dont-desc { font-size: 11px; color: var(--stardust); line-height: 1.4; }
+
+  .dont-squish { transform: scaleX(0.6); }
+  .dont-stretch { transform: scaleY(0.5); }
+  .dont-rotate { transform: rotate(35deg) scale(0.8); }
+  .dont-low-contrast { filter: contrast(0.2) brightness(0.5); }
+  .dont-busy { filter: drop-shadow(0 0 6px red) drop-shadow(0 0 12px blue) drop-shadow(0 0 18px green); }
+  .dont-outline { -webkit-text-fill-color: transparent; -webkit-text-stroke: 1px rgba(255,255,255,0.4); font-family: 'Bebas Neue'; font-size: 28px; letter-spacing: 0.1em; color: transparent; }
+
+</style>
+</head>
+<body>
+
+<!-- STARFIELD -->
+<div class="starfield" id="stars"></div>
+
+<!-- NAV -->
+<nav class="toc">
+  <div class="toc-brand">MMF</div>
+  <a href="#logo">Logo</a>
+  <a href="#palette">Colors</a>
+  <a href="#typography">Type</a>
+  <a href="#ui">UI Kit</a>
+  <a href="#voice">Voice</a>
+  <a href="#motion">Motion</a>
+</nav>
+
+<div class="page">
+
+  <!-- COVER -->
+  <div class="cover">
+    <div class="cover-inner">
+      <div class="brand-badge">Brand Identity Guidelines v1.0</div>
+      <h1>MARS<br>MISSION<br>FUND</h1>
+      <div class="cover-subtitle">Brand Guidelines</div>
+      <p class="cover-desc">A complete visual identity system for the crowdfunding platform that turns ordinary investors into mission backers — funding humanity's next great leap to the red planet.</p>
+      <div class="doc-meta">
+        <div class="meta-item">
+          <div class="meta-label">Version</div>
+          <div class="meta-value">1.0</div>
+        </div>
+        <div class="meta-item">
+          <div class="meta-label">Audience</div>
+          <div class="meta-value">Design & Dev Teams</div>
+        </div>
+        <div class="meta-item">
+          <div class="meta-label">Last Updated</div>
+          <div class="meta-value">2026</div>
+        </div>
+        <div class="meta-item">
+          <div class="meta-label">Status</div>
+          <div class="meta-value" style="color:var(--success)">Live</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="divider"></div>
+
+  <!-- LOGO -->
+  <section id="logo">
+    <div class="section-label">01 — Identity</div>
+    <h2 class="section-title">The <span>Logo</span></h2>
+    <p class="section-intro">The Mars Mission Fund mark fuses a metallic coin — symbol of capital, trust, and value — with Mars itself embedded within it. Together they say: your money is going somewhere extraordinary.</p>
+
+    <!-- LOGO CARDS -->
+    <div class="logo-showcase">
+
+      <!-- Primary Dark -->
+      <div class="logo-card dark">
+        <div class="mmf-logo">
+          <!-- COIN SVG - Primary -->
+          <svg class="coin-svg" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <radialGradient id="coinGrad" cx="35%" cy="30%" r="70%">
+                <stop offset="0%" stop-color="#E8EDF5"/>
+                <stop offset="40%" stop-color="#C8D0DC"/>
+                <stop offset="75%" stop-color="#8A96A8"/>
+                <stop offset="100%" stop-color="#5A6475"/>
+              </radialGradient>
+              <radialGradient id="coinInner" cx="40%" cy="35%" r="65%">
+                <stop offset="0%" stop-color="#1A3A6E"/>
+                <stop offset="50%" stop-color="#0B1628"/>
+                <stop offset="100%" stop-color="#060A14"/>
+              </radialGradient>
+              <radialGradient id="marsGrad" cx="40%" cy="35%" r="65%">
+                <stop offset="0%" stop-color="#FF8C42"/>
+                <stop offset="45%" stop-color="#C1440E"/>
+                <stop offset="100%" stop-color="#7A2A0A"/>
+              </radialGradient>
+              <filter id="glow">
+                <feGaussianBlur stdDeviation="2" result="blur"/>
+                <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+              </filter>
+              <clipPath id="coinClip">
+                <circle cx="60" cy="60" r="50"/>
+              </clipPath>
+            </defs>
+            <!-- Outer ring -->
+            <circle cx="60" cy="60" r="58" fill="url(#coinGrad)" opacity="0.3"/>
+            <!-- Coin body -->
+            <circle cx="60" cy="60" r="52" fill="url(#coinGrad)"/>
+            <!-- Inner recess -->
+            <circle cx="60" cy="60" r="44" fill="url(#coinInner)"/>
+            <!-- Ridge detail -->
+            <circle cx="60" cy="60" r="48" fill="none" stroke="rgba(200,208,220,0.15)" stroke-width="1"/>
+            <circle cx="60" cy="60" r="46" fill="none" stroke="rgba(200,208,220,0.08)" stroke-width="0.5"/>
+            <!-- MARS PLANET -->
+            <circle cx="60" cy="60" r="24" fill="url(#marsGrad)"/>
+            <!-- Mars surface details -->
+            <ellipse cx="52" cy="56" rx="5" ry="3" fill="rgba(90,30,10,0.5)" transform="rotate(-15,52,56)"/>
+            <ellipse cx="68" cy="58" rx="4" ry="2" fill="rgba(90,30,10,0.4)" transform="rotate(10,68,58)"/>
+            <ellipse cx="60" cy="50" rx="7" ry="2.5" fill="rgba(255,140,66,0.4)" transform="rotate(-5,60,50)"/>
+            <ellipse cx="57" cy="68" rx="3" ry="2" fill="rgba(90,30,10,0.3)" transform="rotate(20,57,68)"/>
+            <!-- Mars polar cap -->
+            <ellipse cx="60" cy="38" rx="6" ry="2.5" fill="rgba(220,230,245,0.4)"/>
+            <!-- Orbital ring around Mars -->
+            <ellipse cx="60" cy="60" rx="32" ry="10" fill="none" stroke="rgba(200,208,220,0.25)" stroke-width="1" stroke-dasharray="3 2" transform="rotate(-25,60,60)"/>
+            <!-- Coin shine highlight -->
+            <ellipse cx="46" cy="36" rx="14" ry="8" fill="rgba(255,255,255,0.12)" transform="rotate(-20,46,36)"/>
+            <!-- $ symbol subtle overlay in coin rim -->
+            <text x="60" y="15" text-anchor="middle" font-size="7" fill="rgba(200,208,220,0.4)" font-family="serif" font-weight="bold">★</text>
+            <text x="60" y="109" text-anchor="middle" font-size="7" fill="rgba(200,208,220,0.4)" font-family="serif" font-weight="bold">★</text>
+          </svg>
+          <div class="logo-wordmark">
+            <div class="wordmark-main" style="color: var(--chrome);">MARS MISSION<br><span style="color:var(--launchfire)">FUND</span></div>
+            <div class="wordmark-sub" style="color:var(--stardust)">Crowdfunding the Next Giant Leap</div>
+          </div>
+        </div>
+        <div class="logo-label">Primary — Dark Background</div>
+      </div>
+
+      <!-- Light bg -->
+      <div class="logo-card light">
+        <div class="mmf-logo">
+          <svg class="coin-svg" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <radialGradient id="coinGrad2" cx="35%" cy="30%" r="70%">
+                <stop offset="0%" stop-color="#C8D0DC"/>
+                <stop offset="50%" stop-color="#8A96A8"/>
+                <stop offset="100%" stop-color="#5A6475"/>
+              </radialGradient>
+              <radialGradient id="marsGrad2" cx="40%" cy="35%" r="65%">
+                <stop offset="0%" stop-color="#FF8C42"/>
+                <stop offset="50%" stop-color="#C1440E"/>
+                <stop offset="100%" stop-color="#7A2A0A"/>
+              </radialGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#coinGrad2)"/>
+            <circle cx="60" cy="60" r="44" fill="#1A3A6E"/>
+            <circle cx="60" cy="60" r="48" fill="none" stroke="rgba(90,100,117,0.3)" stroke-width="1"/>
+            <circle cx="60" cy="60" r="24" fill="url(#marsGrad2)"/>
+            <ellipse cx="52" cy="56" rx="5" ry="3" fill="rgba(90,30,10,0.5)" transform="rotate(-15,52,56)"/>
+            <ellipse cx="68" cy="58" rx="4" ry="2" fill="rgba(90,30,10,0.4)" transform="rotate(10,68,58)"/>
+            <ellipse cx="60" cy="50" rx="7" ry="2.5" fill="rgba(255,140,66,0.4)" transform="rotate(-5,60,50)"/>
+            <ellipse cx="60" cy="38" rx="6" ry="2.5" fill="rgba(220,230,245,0.5)"/>
+            <ellipse cx="60" cy="60" rx="32" ry="10" fill="none" stroke="rgba(200,208,220,0.3)" stroke-width="1" stroke-dasharray="3 2" transform="rotate(-25,60,60)"/>
+            <ellipse cx="46" cy="36" rx="14" ry="8" fill="rgba(255,255,255,0.15)" transform="rotate(-20,46,36)"/>
+          </svg>
+          <div class="logo-wordmark">
+            <div class="wordmark-main" style="color: #1A3A6E;">MARS MISSION<br><span style="color:var(--launchfire)">FUND</span></div>
+            <div class="wordmark-sub" style="color:#5A6475;">Crowdfunding the Next Giant Leap</div>
+          </div>
+        </div>
+        <div class="logo-label" style="color:#5A6475;">Reversed — Light Background</div>
+      </div>
+
+      <!-- Horizontal lockup -->
+      <div class="logo-card space">
+        <div class="mmf-logo" style="flex-direction:row; gap:24px; align-items:center;">
+          <svg width="72" height="72" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <radialGradient id="cg3" cx="35%" cy="30%" r="70%">
+                <stop offset="0%" stop-color="#E8EDF5"/>
+                <stop offset="50%" stop-color="#C8D0DC"/>
+                <stop offset="100%" stop-color="#5A6475"/>
+              </radialGradient>
+              <radialGradient id="mg3" cx="40%" cy="35%" r="65%">
+                <stop offset="0%" stop-color="#FF8C42"/>
+                <stop offset="50%" stop-color="#C1440E"/>
+                <stop offset="100%" stop-color="#7A2A0A"/>
+              </radialGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#cg3)"/>
+            <circle cx="60" cy="60" r="44" fill="#060A14"/>
+            <circle cx="60" cy="60" r="48" fill="none" stroke="rgba(200,208,220,0.15)" stroke-width="1"/>
+            <circle cx="60" cy="60" r="24" fill="url(#mg3)"/>
+            <ellipse cx="52" cy="56" rx="5" ry="3" fill="rgba(90,30,10,0.5)" transform="rotate(-15,52,56)"/>
+            <ellipse cx="68" cy="58" rx="4" ry="2" fill="rgba(90,30,10,0.4)" transform="rotate(10,68,58)"/>
+            <ellipse cx="60" cy="38" rx="6" ry="2.5" fill="rgba(220,230,245,0.4)"/>
+            <ellipse cx="60" cy="60" rx="32" ry="10" fill="none" stroke="rgba(200,208,220,0.25)" stroke-width="1" stroke-dasharray="3 2" transform="rotate(-25,60,60)"/>
+            <ellipse cx="46" cy="36" rx="14" ry="8" fill="rgba(255,255,255,0.12)" transform="rotate(-20,46,36)"/>
+          </svg>
+          <div>
+            <div style="font-family:'Bebas Neue',sans-serif; font-size:28px; letter-spacing:0.08em; color:var(--chrome); line-height:1;">MARS MISSION <span style="color:var(--launchfire)">FUND</span></div>
+            <div style="font-family:'Space Mono',monospace; font-size:9px; letter-spacing:0.3em; color:var(--stardust); margin-top:4px;">CROWDFUNDING THE NEXT GIANT LEAP</div>
+          </div>
+        </div>
+        <div class="logo-label">Horizontal Lockup</div>
+      </div>
+
+      <!-- Fire bg -->
+      <div class="logo-card fire">
+        <div class="mmf-logo">
+          <svg class="coin-svg" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <radialGradient id="cg4" cx="35%" cy="30%" r="70%">
+                <stop offset="0%" stop-color="rgba(255,255,255,0.9)"/>
+                <stop offset="40%" stop-color="rgba(255,255,255,0.6)"/>
+                <stop offset="100%" stop-color="rgba(255,255,255,0.3)"/>
+              </radialGradient>
+              <radialGradient id="mg4" cx="40%" cy="35%" r="65%">
+                <stop offset="0%" stop-color="rgba(255,255,255,0.5)"/>
+                <stop offset="50%" stop-color="rgba(255,255,255,0.2)"/>
+                <stop offset="100%" stop-color="rgba(255,255,255,0.05)"/>
+              </radialGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#cg4)"/>
+            <circle cx="60" cy="60" r="44" fill="rgba(0,0,0,0.3)"/>
+            <circle cx="60" cy="60" r="24" fill="url(#mg4)"/>
+            <ellipse cx="60" cy="38" rx="6" ry="2.5" fill="rgba(255,255,255,0.4)"/>
+            <ellipse cx="60" cy="60" rx="32" ry="10" fill="none" stroke="rgba(255,255,255,0.3)" stroke-width="1" stroke-dasharray="3 2" transform="rotate(-25,60,60)"/>
+          </svg>
+          <div class="logo-wordmark">
+            <div class="wordmark-main" style="color:white;">MARS MISSION<br>FUND</div>
+            <div class="wordmark-sub" style="color:rgba(255,255,255,0.6);">Crowdfunding the Next Giant Leap</div>
+          </div>
+        </div>
+        <div class="logo-label" style="color:rgba(255,255,255,0.5);">White — On Color</div>
+      </div>
+    </div>
+
+    <!-- ICON VARIANTS -->
+    <h3 style="font-family:'Bebas Neue',sans-serif; font-size:32px; letter-spacing:0.05em; color:var(--chrome); margin-bottom:8px;">Icon Mark</h3>
+    <p style="color:var(--stardust); font-size:14px; margin-bottom:24px;">Use the standalone coin mark at sizes where the full wordmark becomes illegible (below 40px height).</p>
+    <div class="icon-grid">
+      <div class="icon-item">
+        <div class="icon-bg dark">
+          <svg width="48" height="48" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <radialGradient id="igs" cx="35%" cy="30%" r="70%">
+                <stop offset="0%" stop-color="#E8EDF5"/>
+                <stop offset="50%" stop-color="#C8D0DC"/>
+                <stop offset="100%" stop-color="#5A6475"/>
+              </radialGradient>
+              <radialGradient id="ims" cx="40%" cy="35%" r="65%">
+                <stop offset="0%" stop-color="#FF8C42"/>
+                <stop offset="50%" stop-color="#C1440E"/>
+                <stop offset="100%" stop-color="#7A2A0A"/>
+              </radialGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#igs)"/>
+            <circle cx="60" cy="60" r="44" fill="#060A14"/>
+            <circle cx="60" cy="60" r="24" fill="url(#ims)"/>
+            <ellipse cx="60" cy="38" rx="6" ry="2.5" fill="rgba(220,230,245,0.4)"/>
+            <ellipse cx="60" cy="60" rx="32" ry="10" fill="none" stroke="rgba(200,208,220,0.2)" stroke-width="1.5" stroke-dasharray="3 2" transform="rotate(-25,60,60)"/>
+          </svg>
+        </div>
+        <div class="icon-label">48px</div>
+      </div>
+      <div class="icon-item">
+        <div class="icon-bg dark" style="width:56px;height:56px;border-radius:14px;">
+          <svg width="36" height="36" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <radialGradient id="igs2" cx="35%" cy="30%" r="70%"><stop offset="0%" stop-color="#E8EDF5"/><stop offset="50%" stop-color="#C8D0DC"/><stop offset="100%" stop-color="#5A6475"/></radialGradient>
+              <radialGradient id="ims2" cx="40%" cy="35%" r="65%"><stop offset="0%" stop-color="#FF8C42"/><stop offset="50%" stop-color="#C1440E"/><stop offset="100%" stop-color="#7A2A0A"/></radialGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#igs2)"/><circle cx="60" cy="60" r="44" fill="#060A14"/><circle cx="60" cy="60" r="24" fill="url(#ims2)"/>
+            <ellipse cx="60" cy="38" rx="6" ry="2.5" fill="rgba(220,230,245,0.4)"/>
+            <ellipse cx="60" cy="60" rx="32" ry="10" fill="none" stroke="rgba(200,208,220,0.2)" stroke-width="1.5" stroke-dasharray="3 2" transform="rotate(-25,60,60)"/>
+          </svg>
+        </div>
+        <div class="icon-label">32px</div>
+      </div>
+      <div class="icon-item">
+        <div class="icon-bg grad" style="width:80px;height:80px;border-radius:22px;">
+          <svg width="52" height="52" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <radialGradient id="igs3" cx="35%" cy="30%" r="70%"><stop offset="0%" stop-color="rgba(255,255,255,0.9)"/><stop offset="100%" stop-color="rgba(255,255,255,0.4)"/></radialGradient>
+              <radialGradient id="ims3" cx="40%" cy="35%" r="65%"><stop offset="0%" stop-color="rgba(255,255,255,0.5)"/><stop offset="100%" stop-color="rgba(255,255,255,0.1)"/></radialGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#igs3)"/><circle cx="60" cy="60" r="44" fill="rgba(0,0,0,0.3)"/><circle cx="60" cy="60" r="24" fill="url(#ims3)"/>
+            <ellipse cx="60" cy="38" rx="6" ry="2.5" fill="rgba(255,255,255,0.4)"/>
+            <ellipse cx="60" cy="60" rx="32" ry="10" fill="none" stroke="rgba(255,255,255,0.3)" stroke-width="1.5" stroke-dasharray="3 2" transform="rotate(-25,60,60)"/>
+          </svg>
+        </div>
+        <div class="icon-label">App Icon</div>
+      </div>
+      <div class="icon-item">
+        <div class="icon-bg dark" style="width:32px;height:32px;border-radius:8px;overflow:hidden;">
+          <svg width="22" height="22" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <radialGradient id="igs4" cx="35%" cy="30%" r="70%"><stop offset="0%" stop-color="#E8EDF5"/><stop offset="100%" stop-color="#5A6475"/></radialGradient>
+              <radialGradient id="ims4" cx="40%" cy="35%" r="65%"><stop offset="0%" stop-color="#FF8C42"/><stop offset="100%" stop-color="#7A2A0A"/></radialGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#igs4)"/><circle cx="60" cy="60" r="44" fill="#060A14"/><circle cx="60" cy="60" r="24" fill="url(#ims4)"/>
+          </svg>
+        </div>
+        <div class="icon-label">16px</div>
+      </div>
+    </div>
+
+    <!-- CLEARSPACE -->
+    <h3 class="mt-64" style="font-family:'Bebas Neue',sans-serif; font-size:32px; letter-spacing:0.05em; color:var(--chrome); margin-bottom:8px;">Clear Space</h3>
+    <p style="color:var(--stardust); font-size:14px; margin-bottom:32px;">Always maintain a minimum clear space equal to the height of the "M" in the wordmark around all sides of the logo mark.</p>
+    <div class="clearspace-demo">
+      <div class="clearspace-inner">
+        <div style="display:flex; align-items:center; gap:16px;">
+          <svg width="56" height="56" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <radialGradient id="cgc" cx="35%" cy="30%" r="70%"><stop offset="0%" stop-color="#E8EDF5"/><stop offset="50%" stop-color="#C8D0DC"/><stop offset="100%" stop-color="#5A6475"/></radialGradient>
+              <radialGradient id="mgc" cx="40%" cy="35%" r="65%"><stop offset="0%" stop-color="#FF8C42"/><stop offset="50%" stop-color="#C1440E"/><stop offset="100%" stop-color="#7A2A0A"/></radialGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#cgc)"/>
+            <circle cx="60" cy="60" r="44" fill="#060A14"/>
+            <circle cx="60" cy="60" r="24" fill="url(#mgc)"/>
+            <ellipse cx="60" cy="38" rx="6" ry="2.5" fill="rgba(220,230,245,0.4)"/>
+            <ellipse cx="60" cy="60" rx="32" ry="10" fill="none" stroke="rgba(200,208,220,0.2)" stroke-width="1.5" stroke-dasharray="3 2" transform="rotate(-25,60,60)"/>
+          </svg>
+          <div style="font-family:'Bebas Neue',sans-serif; font-size:26px; letter-spacing:0.08em; color:var(--chrome);">MARS MISSION <span style="color:var(--launchfire)">FUND</span></div>
+        </div>
+      </div>
+      <div class="clearspace-label">← Minimum clear space: 1× coin diameter →</div>
+    </div>
+
+    <!-- DON'T -->
+    <h3 class="mt-64" style="font-family:'Bebas Neue',sans-serif; font-size:32px; letter-spacing:0.05em; color:var(--chrome); margin-bottom:8px;">Logo Don'ts</h3>
+    <p style="color:var(--stardust); font-size:14px; margin-bottom:0;">Never alter, distort, or misuse the logo in these ways.</p>
+    <div class="dont-grid">
+      <div class="dont-card">
+        <div class="dont-logo-area"><span class="dont-outline">MMF</span></div>
+        <div class="dont-title">Don't outline</div>
+        <div class="dont-desc">Never create an outlined or stroked version of the wordmark</div>
+      </div>
+      <div class="dont-card">
+        <div class="dont-logo-area">
+          <div style="font-family:'Bebas Neue',sans-serif; font-size:22px; color:var(--chrome); transform:scaleX(0.55);">MARS MISSION FUND</div>
+        </div>
+        <div class="dont-title">Don't squish</div>
+        <div class="dont-desc">Never stretch or compress the logo disproportionately</div>
+      </div>
+      <div class="dont-card">
+        <div class="dont-logo-area">
+          <div style="font-family:'Bebas Neue',sans-serif; font-size:18px; color:rgba(200,208,220,0.2);">MARS MISSION FUND</div>
+        </div>
+        <div class="dont-title">Don't fade</div>
+        <div class="dont-desc">Never use the logo below minimum contrast on any background</div>
+      </div>
+    </div>
+  </section>
+
+  <div class="divider"></div>
+
+  <!-- COLOR PALETTE -->
+  <section id="palette">
+    <div class="section-label">02 — Color</div>
+    <h2 class="section-title">The <span>Palette</span></h2>
+    <p class="section-intro">Four systems working in concert: deep-space foundations, launch-fire energy, mission-success green, and metallic silver for trust and finish.</p>
+
+    <div class="palette-group">
+      <div class="palette-group-title">01 / Deep Space — Foundation</div>
+      <div class="palette-row">
+        <div class="swatch">
+          <div class="swatch-color swatch-primary"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Void</div>
+            <div class="swatch-hex">#060A14</div>
+            <div class="swatch-use">Primary background, deepest contrast</div>
+          </div>
+        </div>
+        <div class="swatch">
+          <div class="swatch-color swatch-deep"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Deep Space</div>
+            <div class="swatch-hex">#0B1628</div>
+            <div class="swatch-use">Card backgrounds, secondary surfaces</div>
+          </div>
+        </div>
+        <div class="swatch">
+          <div class="swatch-color swatch-nebula"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Nebula</div>
+            <div class="swatch-hex">#0E2040</div>
+            <div class="swatch-use">Elevated surfaces, hover states</div>
+          </div>
+        </div>
+        <div class="swatch">
+          <div class="swatch-color swatch-orbit"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Orbit</div>
+            <div class="swatch-hex">#1A3A6E</div>
+            <div class="swatch-use">Borders, dividers, subtle emphasis</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="palette-group">
+      <div class="palette-group-title">02 / Launch Fire — Energy</div>
+      <div class="palette-row">
+        <div class="swatch">
+          <div class="swatch-color swatch-launch"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Launchfire</div>
+            <div class="swatch-hex">#FF5C1A</div>
+            <div class="swatch-use">Primary CTA, brand accent, links</div>
+          </div>
+        </div>
+        <div class="swatch">
+          <div class="swatch-color swatch-ignition"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Ignition</div>
+            <div class="swatch-hex">#FF8C42</div>
+            <div class="swatch-use">Hover states, secondary CTA, icons</div>
+          </div>
+        </div>
+        <div class="swatch">
+          <div class="swatch-color swatch-afterburn"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Afterburn</div>
+            <div class="swatch-hex">#FFB347</div>
+            <div class="swatch-use">Progress fills, gradient endpoints</div>
+          </div>
+        </div>
+        <div class="swatch">
+          <div class="swatch-color swatch-mars"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Red Planet</div>
+            <div class="swatch-hex">#C1440E</div>
+            <div class="swatch-use">Mars imagery, deep accent tones</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="palette-group">
+      <div class="palette-group-title">03 / Metallic Silver — Trust & Finish</div>
+      <div class="palette-row">
+        <div class="swatch">
+          <div class="swatch-color swatch-chrome"></div>
+          <div class="swatch-info">
+            <div class="swatch-name" style="color:#1A1A1A">Chrome</div>
+            <div class="swatch-hex" style="color:#444">#E8EDF5</div>
+            <div class="swatch-use" style="color:#666">Primary text on dark backgrounds</div>
+          </div>
+        </div>
+        <div class="swatch">
+          <div class="swatch-color swatch-silver"></div>
+          <div class="swatch-info">
+            <div class="swatch-name" style="color:#1A1A1A">Silver</div>
+            <div class="swatch-hex" style="color:#444">#C8D0DC</div>
+            <div class="swatch-use" style="color:#666">Secondary text, coin highlights</div>
+          </div>
+        </div>
+        <div class="swatch">
+          <div class="swatch-color swatch-stardust"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Stardust</div>
+            <div class="swatch-hex">#8A96A8</div>
+            <div class="swatch-use">Tertiary text, placeholders, labels</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="palette-group">
+      <div class="palette-group-title">04 / Success Green — Mission Complete</div>
+      <div class="palette-row" style="max-width:320px;">
+        <div class="swatch">
+          <div class="swatch-color swatch-success"></div>
+          <div class="swatch-info">
+            <div class="swatch-name">Mission Success</div>
+            <div class="swatch-hex">#2FE8A2</div>
+            <div class="swatch-use">Funded badges, success states, gain indicators</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- GRADIENTS -->
+    <h3 style="font-family:'Bebas Neue',sans-serif; font-size:40px; letter-spacing:0.05em; color:var(--chrome); margin-bottom:8px;">Branded Gradients</h3>
+    <p style="color:var(--stardust); font-size:14px;">Use these approved gradient combinations for hero sections, CTAs, and visual emphasis.</p>
+    <div class="gradient-row">
+      <div class="grad-card">
+        <div class="grad-swatch" style="background: linear-gradient(135deg, #FF5C1A, #FF8C42, #FFB347);"></div>
+        <div class="grad-info">
+          <div class="grad-name">Launch Sequence</div>
+          <div class="grad-value">#FF5C1A → #FFB347</div>
+          <div class="grad-use">Primary CTAs, hero backgrounds</div>
+        </div>
+      </div>
+      <div class="grad-card">
+        <div class="grad-swatch" style="background: linear-gradient(135deg, #060A14, #0E2040, #1A3A6E);"></div>
+        <div class="grad-info">
+          <div class="grad-name">Deep Field</div>
+          <div class="grad-value">#060A14 → #1A3A6E</div>
+          <div class="grad-use">Card gradients, page sections</div>
+        </div>
+      </div>
+      <div class="grad-card">
+        <div class="grad-swatch" style="background: linear-gradient(135deg, #E8EDF5, #C8D0DC, #8A96A8);"></div>
+        <div class="grad-info">
+          <div class="grad-name">Metallic Sheen</div>
+          <div class="grad-value">#E8EDF5 → #8A96A8</div>
+          <div class="grad-use">Coin renders, achievement badges</div>
+        </div>
+      </div>
+      <div class="grad-card">
+        <div class="grad-swatch" style="background: linear-gradient(135deg, #C1440E, #FF5C1A, #FF8C42);"></div>
+        <div class="grad-info">
+          <div class="grad-name">Mars Atmosphere</div>
+          <div class="grad-value">#C1440E → #FF8C42</div>
+          <div class="grad-use">Mars imagery, campaign heroes</div>
+        </div>
+      </div>
+      <div class="grad-card">
+        <div class="grad-swatch" style="background: linear-gradient(135deg, #060A14 0%, #0B1628 50%, rgba(255,92,26,0.15) 100%);"></div>
+        <div class="grad-info">
+          <div class="grad-name">Night Launch</div>
+          <div class="grad-value">Void + Launchfire glow</div>
+          <div class="grad-use">Landing page hero, dark overlays</div>
+        </div>
+      </div>
+      <div class="grad-card">
+        <div class="grad-swatch" style="background: linear-gradient(135deg, #0B1628, rgba(47,232,162,0.2), #0B1628);"></div>
+        <div class="grad-info">
+          <div class="grad-name">Mission Success</div>
+          <div class="grad-value">Deep Space + Success glow</div>
+          <div class="grad-use">Funded campaign celebrations</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="divider"></div>
+
+  <!-- TYPOGRAPHY -->
+  <section id="typography">
+    <div class="section-label">03 — Type</div>
+    <h2 class="section-title">Type<span>faces</span></h2>
+    <p class="section-intro">Three typefaces. Each with a distinct mission: commanding display presence, intelligent readability, and technical precision.</p>
+
+    <!-- BEBAS NEUE -->
+    <div class="font-card" data-font="Bb">
+      <div class="font-meta">
+        <div class="font-name-block">
+          <div class="font-role">Display / Headlines</div>
+          <div class="font-name">Bebas Neue</div>
+          <div class="font-source">Google Fonts · Free · 1 weight</div>
+        </div>
+        <div class="font-tags">
+          <span class="tag">Impact</span>
+          <span class="tag">Futuristic</span>
+          <span class="tag">All-caps</span>
+        </div>
+      </div>
+      <div class="type-specimen-text">
+        <div class="specimen-display">FUNDING<br>THE NEXT<br>GIANT LEAP</div>
+        <div class="specimen-alpha">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</div>
+        <div class="specimen-nums">0 1 2 3 4 5 6 7 8 9 ! ? & $ %</div>
+      </div>
+    </div>
+
+    <!-- DM SANS -->
+    <div class="font-card" data-font="Dm">
+      <div class="font-meta">
+        <div class="font-name-block">
+          <div class="font-role">Body / UI / Buttons</div>
+          <div class="font-name">DM Sans</div>
+          <div class="font-source">Google Fonts · Free · Variable weight 100–900</div>
+        </div>
+        <div class="font-tags">
+          <span class="tag blue">Readable</span>
+          <span class="tag blue">Modern</span>
+          <span class="tag blue">Professional</span>
+        </div>
+      </div>
+      <div class="type-specimen-text">
+        <p class="specimen-body">Mars Mission Fund connects visionary investors with the teams building humanity's multiplanetary future. Every contribution moves the mission forward — one launch at a time.</p>
+        <p class="specimen-body-sm">Invest in orbital infrastructure, habitat modules, life-support systems, and the engineering teams designing the technology stack for long-duration spaceflight. Starting at $50 per mission stake.</p>
+      </div>
+    </div>
+
+    <!-- SPACE MONO -->
+    <div class="font-card" data-font="Sm">
+      <div class="font-meta">
+        <div class="font-name-block">
+          <div class="font-role">Data / Labels / Code / Tags</div>
+          <div class="font-name">Space Mono</div>
+          <div class="font-source">Google Fonts · Free · 2 weights</div>
+        </div>
+        <div class="font-tags">
+          <span class="tag green">Technical</span>
+          <span class="tag green">Data</span>
+          <span class="tag green">Monospace</span>
+        </div>
+      </div>
+      <div class="type-specimen-text">
+        <div class="specimen-mono">
+          MISSION_ID: MMF-2026-MARS-041<br>
+          FUNDING_TARGET: $4,200,000 USD<br>
+          RAISED_TO_DATE: $3,108,400 (73.9%)<br>
+          T_MINUS: 18d 04h 22m 11s<br>
+          STATUS: ACTIVE — ACCEPTING STAKES
+        </div>
+      </div>
+    </div>
+
+    <!-- TYPE SCALE -->
+    <h3 style="font-family:'Bebas Neue',sans-serif; font-size:40px; letter-spacing:0.05em; color:var(--chrome); margin-bottom:8px;" class="mt-48">Type Scale</h3>
+    <p style="color:var(--stardust); font-size:14px; margin-bottom:24px;">A complete modular scale for consistent hierarchy across all surfaces.</p>
+    <div class="type-scale">
+      <div class="scale-row">
+        <div class="scale-label">Hero / 96px</div>
+        <div class="scale-example" style="font-family:'Bebas Neue',sans-serif; font-size:clamp(32px,5vw,72px); letter-spacing:0.03em; line-height:1;">LAUNCH SEQUENCE</div>
+      </div>
+      <div class="scale-row">
+        <div class="scale-label">H1 / 56px</div>
+        <div class="scale-example" style="font-family:'Bebas Neue',sans-serif; font-size:clamp(28px,4vw,48px); letter-spacing:0.04em; line-height:1;">Mars Mission 041</div>
+      </div>
+      <div class="scale-row">
+        <div class="scale-label">H2 / 40px</div>
+        <div class="scale-example" style="font-family:'Bebas Neue',sans-serif; font-size:clamp(24px,3vw,36px); letter-spacing:0.04em; line-height:1.1;">Habitat Module Campaign</div>
+      </div>
+      <div class="scale-row">
+        <div class="scale-label">H3 / 24px</div>
+        <div class="scale-example" style="font-family:'DM Sans',sans-serif; font-size:20px; font-weight:700;">Mission Details & Milestones</div>
+      </div>
+      <div class="scale-row">
+        <div class="scale-label">Body / 16px</div>
+        <div class="scale-example" style="font-family:'DM Sans',sans-serif; font-size:16px; font-weight:400; color:var(--silver);">Your investment funds the teams designing pressurized habitats for six-person crews.</div>
+      </div>
+      <div class="scale-row">
+        <div class="scale-label">Small / 13px</div>
+        <div class="scale-example" style="font-family:'DM Sans',sans-serif; font-size:13px; font-weight:400; color:var(--stardust);">All investments are subject to mission risk. Past performance is not indicative of future results.</div>
+      </div>
+      <div class="scale-row">
+        <div class="scale-label">Label / 11px</div>
+        <div class="scale-example" style="font-family:'Space Mono',monospace; font-size:11px; letter-spacing:0.2em; text-transform:uppercase; color:var(--launchfire);">MISSION STATUS · ACTIVE</div>
+      </div>
+    </div>
+  </section>
+
+  <div class="divider"></div>
+
+  <!-- UI KIT -->
+  <section id="ui">
+    <div class="section-label">04 — UI Components</div>
+    <h2 class="section-title">UI <span>Kit</span></h2>
+    <p class="section-intro">Core component patterns built from the brand system. Consistent, accessible, and unmistakably Mars Mission Fund.</p>
+
+    <div class="ui-samples">
+
+      <!-- Buttons -->
+      <div class="ui-card">
+        <div style="font-family:'Space Mono',monospace; font-size:10px; letter-spacing:0.2em; color:var(--stardust); text-transform:uppercase; margin-bottom:20px;">Buttons</div>
+        <div class="btn-row">
+          <button class="btn btn-primary">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+            Back This Mission
+          </button>
+          <button class="btn btn-secondary">View Details</button>
+        </div>
+        <div class="btn-row" style="margin-top:12px;">
+          <button class="btn btn-ghost">Learn More</button>
+          <button class="btn btn-success">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+            Funded!
+          </button>
+        </div>
+      </div>
+
+      <!-- Stats -->
+      <div class="ui-card">
+        <div style="font-family:'Space Mono',monospace; font-size:10px; letter-spacing:0.2em; color:var(--stardust); text-transform:uppercase; margin-bottom:20px;">Mission Stats</div>
+        <div class="stat-grid">
+          <div class="stat-card">
+            <div class="stat-label">Raised</div>
+            <div class="stat-value" style="font-size:28px;">$3.1M</div>
+            <div class="stat-sub">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"/></svg>
+              73.9% funded
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">Backers</div>
+            <div class="stat-value" style="font-size:28px;">2,841</div>
+            <div class="stat-sub">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"/></svg>
+              +124 today
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">Days Left</div>
+            <div class="stat-value" style="font-size:28px; color:var(--ignition);">18</div>
+            <div class="stat-sub" style="color:var(--stardust);">Closes Mar 21</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">Min. Stake</div>
+            <div class="stat-value" style="font-size:28px; color:var(--silver);">$50</div>
+            <div class="stat-sub" style="color:var(--stardust);">Any amount</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Progress -->
+      <div class="ui-card">
+        <div style="font-family:'Space Mono',monospace; font-size:10px; letter-spacing:0.2em; color:var(--stardust); text-transform:uppercase; margin-bottom:20px;">Progress Tracker</div>
+        <div class="progress-block">
+          <div class="progress-header">
+            <div class="progress-title">Habitat Module Alpha</div>
+            <div class="progress-pct">73%</div>
+          </div>
+          <div class="progress-bar">
+            <div class="progress-fill" style="width:73%;"></div>
+          </div>
+          <div style="display:flex; justify-content:space-between; margin-top:8px;">
+            <span style="font-size:12px; color:var(--stardust);">$3,108,400 raised</span>
+            <span style="font-size:12px; color:var(--stardust);">Goal: $4,200,000</span>
+          </div>
+        </div>
+        <div class="progress-block" style="margin-top:20px;">
+          <div class="progress-header">
+            <div class="progress-title">Propulsion System R&D</div>
+            <div class="progress-pct" style="color:var(--success);">100%</div>
+          </div>
+          <div class="progress-bar">
+            <div class="progress-fill" style="width:100%; background: linear-gradient(90deg, var(--success), #1AB878);"></div>
+          </div>
+          <div style="margin-top:8px;">
+            <span style="font-size:12px; color:var(--success);">✓ Fully funded — Mission complete</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Badges & Input -->
+      <div class="ui-card">
+        <div style="font-family:'Space Mono',monospace; font-size:10px; letter-spacing:0.2em; color:var(--stardust); text-transform:uppercase; margin-bottom:20px;">Status Badges</div>
+        <div class="badge-row">
+          <span class="badge badge-funded"><span class="badge-dot green"></span>Funded</span>
+          <span class="badge badge-active"><span class="badge-dot orange"></span>Live Now</span>
+          <span class="badge badge-new"><span class="badge-dot blue"></span>New Mission</span>
+        </div>
+        <div class="input-block">
+          <div class="input-label">Investment Amount</div>
+          <div class="input-wrap">
+            <input class="input-field" type="text" value="250" />
+            <span class="input-suffix">USD</span>
+          </div>
+        </div>
+        <div class="input-block">
+          <div class="input-label">Mission Code</div>
+          <div class="input-wrap">
+            <input class="input-field" type="text" placeholder="MMF-2026-XXXX" style="color:var(--stardust);" />
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <div class="divider"></div>
+
+  <!-- VOICE & TONE -->
+  <section id="voice">
+    <div class="section-label">05 — Voice</div>
+    <h2 class="section-title">Voice <span>&</span> Tone</h2>
+    <p class="section-intro">Mars Mission Fund speaks like a brilliant, optimistic engineer who also happens to be brilliant at making complex things feel exciting to anyone.</p>
+
+    <div class="voice-grid">
+      <div class="voice-card do">
+        <div class="voice-header do"><span class="voice-icon">✓</span> Do write this way</div>
+        <ul class="voice-examples">
+          <li>Back the team building pressurized habitats for the first Mars crews</li>
+          <li>73% funded — 18 days left to join the mission</li>
+          <li>Every $50 moves the launch window closer</li>
+          <li>Your stake. Their mission. Our planet.</li>
+          <li>Funding opens March 1. Liftoff begins March 21.</li>
+        </ul>
+      </div>
+      <div class="voice-card dont">
+        <div class="voice-header dont"><span class="voice-icon">✕</span> Avoid this language</div>
+        <ul class="voice-examples">
+          <li>Please consider investing in our exciting new venture opportunity</li>
+          <li>Utilizing synergistic technologies for next-gen planetary colonization</li>
+          <li>Click here to learn more about our financial product</li>
+          <li>Results may not be as depicted. This is not investment advice.</li>
+          <li>Our revolutionary disruptive space platform solutions</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="mt-48" style="background: var(--deep-space); border: 1px solid rgba(255,255,255,0.06); border-radius: 20px; padding: 40px;">
+      <div style="font-family:'Space Mono',monospace; font-size:10px; letter-spacing:0.2em; color:var(--launchfire); text-transform:uppercase; margin-bottom:24px;">Brand Personality Axes</div>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:32px;">
+        <div>
+          <div style="display:flex; justify-content:space-between; font-size:12px; color:var(--stardust); margin-bottom:8px;"><span>Playful</span><span>Serious</span></div>
+          <div style="height:6px; background:rgba(255,255,255,0.06); border-radius:100px; overflow:hidden;"><div style="width:40%; height:100%; background:linear-gradient(90deg,var(--launchfire),var(--ignition));"></div></div>
+          <div style="font-size:11px; color:var(--stardust); margin-top:6px;">Leans playful — but never flippant</div>
+        </div>
+        <div>
+          <div style="display:flex; justify-content:space-between; font-size:12px; color:var(--stardust); margin-bottom:8px;"><span>Technical</span><span>Accessible</span></div>
+          <div style="height:6px; background:rgba(255,255,255,0.06); border-radius:100px; overflow:hidden;"><div style="width:65%; height:100%; background:linear-gradient(90deg,var(--launchfire),var(--ignition));"></div></div>
+          <div style="font-size:11px; color:var(--stardust); margin-top:6px;">Precise, but never alienating</div>
+        </div>
+        <div>
+          <div style="display:flex; justify-content:space-between; font-size:12px; color:var(--stardust); margin-bottom:8px;"><span>Cautious</span><span>Bold</span></div>
+          <div style="height:6px; background:rgba(255,255,255,0.06); border-radius:100px; overflow:hidden;"><div style="width:80%; height:100%; background:linear-gradient(90deg,var(--launchfire),var(--ignition));"></div></div>
+          <div style="font-size:11px; color:var(--stardust); margin-top:6px;">Leans confidently bold</div>
+        </div>
+        <div>
+          <div style="display:flex; justify-content:space-between; font-size:12px; color:var(--stardust); margin-bottom:8px;"><span>Formal</span><span>Human</span></div>
+          <div style="height:6px; background:rgba(255,255,255,0.06); border-radius:100px; overflow:hidden;"><div style="width:70%; height:100%; background:linear-gradient(90deg,var(--launchfire),var(--ignition));"></div></div>
+          <div style="font-size:11px; color:var(--stardust); margin-top:6px;">Warm and direct, not corporate</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="divider"></div>
+
+  <!-- MOTION -->
+  <section id="motion">
+    <div class="section-label">06 — Motion</div>
+    <h2 class="section-title">Motion <span>&</span> Feel</h2>
+    <p class="section-intro">Animation mirrors the physical reality of spaceflight — dramatic acceleration, precise control, moments of weightlessness, and ignition events that demand attention.</p>
+
+    <div class="motion-row">
+      <div class="motion-card">
+        <div class="motion-vis m-ease-out">
+          <div class="motion-dot"></div>
+        </div>
+        <div class="motion-name">Gravity Assist</div>
+        <div class="motion-spec">ease-out · 300–500ms</div>
+        <div style="font-size:11px; color:var(--stardust); margin-top:8px; line-height:1.4;">Elements enter fast and settle smoothly</div>
+      </div>
+      <div class="motion-card">
+        <div class="motion-vis m-spring">
+          <div class="motion-dot"></div>
+        </div>
+        <div class="motion-name">Bounce Deploy</div>
+        <div class="motion-spec">spring · 400ms · overshoot</div>
+        <div style="font-size:11px; color:var(--stardust); margin-top:8px; line-height:1.4;">CTAs, modals, and success states</div>
+      </div>
+      <div class="motion-card">
+        <div class="motion-vis m-float">
+          <div class="motion-dot"></div>
+        </div>
+        <div class="motion-name">Zero Gravity</div>
+        <div class="motion-spec">ease-in-out · 2–4s · infinite</div>
+        <div style="font-size:11px; color:var(--stardust); margin-top:8px; line-height:1.4;">Decorative elements and hero imagery</div>
+      </div>
+      <div class="motion-card">
+        <div class="motion-vis m-ignite">
+          <div class="motion-dot"></div>
+        </div>
+        <div class="motion-name">Ignition</div>
+        <div class="motion-spec">ease-in-out · 1.5s · glow pulse</div>
+        <div style="font-size:11px; color:var(--stardust); margin-top:8px; line-height:1.4;">Live countdowns and urgent states</div>
+      </div>
+    </div>
+
+    <!-- Timing tokens -->
+    <div class="mt-48" style="background: var(--deep-space); border: 1px solid rgba(255,255,255,0.06); border-radius: 20px; padding: 40px;">
+      <div style="font-family:'Space Mono',monospace; font-size:10px; letter-spacing:0.2em; color:var(--launchfire); text-transform:uppercase; margin-bottom:24px;">Timing Tokens</div>
+      <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:20px;">
+        <div>
+          <div style="font-family:'Space Mono',monospace; font-size:11px; color:var(--success); margin-bottom:4px;">--duration-fast</div>
+          <div style="font-size:22px; font-family:'Bebas Neue',sans-serif; letter-spacing:0.05em; color:var(--chrome);">150ms</div>
+          <div style="font-size:11px; color:var(--stardust);">Hover states, icon transitions</div>
+        </div>
+        <div>
+          <div style="font-family:'Space Mono',monospace; font-size:11px; color:var(--success); margin-bottom:4px;">--duration-base</div>
+          <div style="font-size:22px; font-family:'Bebas Neue',sans-serif; letter-spacing:0.05em; color:var(--chrome);">300ms</div>
+          <div style="font-size:11px; color:var(--stardust);">Page elements, cards entering</div>
+        </div>
+        <div>
+          <div style="font-family:'Space Mono',monospace; font-size:11px; color:var(--success); margin-bottom:4px;">--duration-medium</div>
+          <div style="font-size:22px; font-family:'Bebas Neue',sans-serif; letter-spacing:0.05em; color:var(--chrome);">500ms</div>
+          <div style="font-size:11px; color:var(--stardust);">Modals, drawers, panels</div>
+        </div>
+        <div>
+          <div style="font-family:'Space Mono',monospace; font-size:11px; color:var(--success); margin-bottom:4px;">--duration-slow</div>
+          <div style="font-size:22px; font-family:'Bebas Neue',sans-serif; letter-spacing:0.05em; color:var(--chrome);">800ms</div>
+          <div style="font-size:11px; color:var(--stardust);">Page transitions, celebrations</div>
+        </div>
+        <div>
+          <div style="font-family:'Space Mono',monospace; font-size:11px; color:var(--success); margin-bottom:4px;">--easing-out</div>
+          <div style="font-size:13px; font-family:'Space Mono',monospace; color:var(--chrome); margin-top:6px;">cubic-bezier<br>(0.25, 1, 0.5, 1)</div>
+          <div style="font-size:11px; color:var(--stardust); margin-top:4px;">Default easing</div>
+        </div>
+        <div>
+          <div style="font-family:'Space Mono',monospace; font-size:11px; color:var(--success); margin-bottom:4px;">--easing-spring</div>
+          <div style="font-size:13px; font-family:'Space Mono',monospace; color:var(--chrome); margin-top:6px;">cubic-bezier<br>(0.34, 1.56, 0.64, 1)</div>
+          <div style="font-size:11px; color:var(--stardust); margin-top:4px;">Energetic, overshooting</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <div class="divider"></div>
+  <div class="brand-footer">
+    <div>
+      <div class="footer-brand">MARS MISSION <span>FUND</span></div>
+      <div style="font-size:13px; color:var(--stardust); margin-top:6px;">Brand Guidelines v1.0 · 2026</div>
+    </div>
+    <div class="footer-note">FOR INTERNAL DESIGN & DEVELOPMENT USE · CONFIDENTIAL</div>
+  </div>
+
+</div>
+
+<script>
+  // Generate stars
+  const starfield = document.getElementById('stars');
+  for (let i = 0; i < 200; i++) {
+    const star = document.createElement('div');
+    star.className = 'star';
+    const size = Math.random() * 2 + 0.5;
+    star.style.cssText = `
+      width: ${size}px;
+      height: ${size}px;
+      left: ${Math.random()*100}%;
+      top: ${Math.random()*100}%;
+      --d: ${(Math.random()*4+2).toFixed(1)}s;
+      --o: ${(Math.random()*0.6+0.2).toFixed(2)};
+      animation-delay: ${(Math.random()*5).toFixed(1)}s;
+    `;
+    starfield.appendChild(star);
+  }
+</script>
+</body>
+</html>

--- a/specs/tech/architecture.md
+++ b/specs/tech/architecture.md
@@ -1,0 +1,426 @@
+# Architecture
+
+> **Spec ID**: L3-001
+> **Version**: 0.3
+> **Status**: Approved
+> **Rate of Change**: Sprint-level / tech decisions
+> **Depends On**: L1-001 (Product Vision & Mission), L2-002 (Engineering Standard), L3-008 (Tech Stack)
+> **Depended On By**: L3-002 (tech/security.md), L3-003 (tech/reliability.md), L3-004 (tech/data-management.md), L3-005 (tech/frontend.md), L3-006 (tech/audit.md), L4-002 (domain/campaign.md), L4-004 (domain/payments.md)
+
+---
+
+## 1. Purpose
+
+> **Local demo scope**: Service boundaries, CQRS/Event Sourcing pattern, REST API design, feature flag framework, and the hexagonal architecture pattern are **real** — they drive the local demo's implementation. Multi-environment deployment, infrastructure topology diagrams, and service discovery are theatre. The local demo runs as a single Docker Compose stack.
+
+This spec defines the system architecture for Mars Mission Fund: service boundaries, data model overview, inter-service communication patterns, infrastructure topology, deployment strategy, and cross-cutting technical frameworks (ADRs, feature flags, linting).
+
+**What this spec governs**:
+
+- High-level system structure and service decomposition.
+- Inter-service communication contracts and patterns.
+- Infrastructure and deployment topology.
+- Technology selection registry and ADR process.
+- Feature flag framework.
+- Linting and formatting rulesets.
+- API versioning scheme and error response format.
+
+**What this spec does NOT cover**:
+
+- Threat models and security controls — see [Security](L3-002).
+- Availability targets, failover, and disaster recovery — see [Reliability](L3-003).
+- Data classification, retention, and lifecycle — see [Data Management](L3-004).
+- Frontend component architecture and browser support — see [Frontend Standards](L3-005).
+- Audit event schemas and log retention — see [Audit](L3-006).
+
+---
+
+## 2. Inherited Constraints
+
+This spec inherits all constraints from the [Engineering Standard](L2-002).
+The following sections are directly implemented or referenced by this spec:
+
+| L2-002 Section | Constraint | How This Spec Implements It |
+| --- | --- | --- |
+| 1.1 Encryption | TLS 1.3 minimum; AES-256 at rest for sensitive data | Section 5 (Infrastructure) defines where termination occurs; [Security](L3-002) defines the certificate and key management details |
+| 1.2 Data Access | Parameterised queries only; data access layer required | Section 4 (Data Model) defines the data access layer pattern |
+| 1.3 Secrets Management | Secrets via dedicated service, injected at runtime | Section 8 (Technology Selection Registry) records the chosen secrets management service |
+| 1.5 Authentication & Authorisation | Every endpoint authenticated; no anonymous internal calls | Section 6.3 (Service Identity) defines the service identity mechanism |
+| 2.4 Abstraction Requirement | External dependencies behind internal interfaces | Section 3.3 (External Integration Adapters) defines the adapter pattern for external integrations |
+| 3.1 Decision Rights | ADR process for multi-service architectural decisions | Section 7 (ADR Process) defines the full process |
+| 4.1 Code Quality | Linting and formatting rulesets per language | Section 10 (Linting & Formatting) defines rulesets |
+| 4.5 Deployment Gates | Feature flags as default for user-facing changes | Section 9 (Feature Flag Framework) defines the framework |
+| 5.1 Versioning | All APIs versioned from day one | Section 6.1 (Synchronous Communication) defines the scheme |
+| 5.3 Error Response Contract | Consistent error format with error code, message, correlation ID | Section 6.1 (Error Response Format) defines the format |
+| 7.1 Environment Parity | Dev, staging, production structurally identical | Section 5 (Infrastructure) defines the environment topology |
+| 7.2 Configuration | Runtime config via environment variables; feature flags via dedicated service | Sections 5 and 9 |
+| 7.4 Deployments | Automated, reproducible, reversible within 15 minutes | Section 5.3 (Deployment Pipeline) |
+
+---
+
+## 3. Service Boundaries & Responsibilities
+
+The system is decomposed into services aligned with the L4 domain boundaries.
+Each service owns its data, exposes a well-defined API, and communicates with other services through the patterns defined in Section 6.
+
+### 3.1 Domain Services
+
+| Service | Governing Spec | Responsibilities |
+| --- | --- | --- |
+| Account Service | [Account](L4-001) | User registration, authentication, profile management, role assignment, session management, account recovery |
+| Campaign Service | [Campaign](L4-002) | Project submission, review pipeline, campaign lifecycle, milestone tracking, deadline enforcement, fund settlement |
+| Donor Service | [Donor](L4-003) | Project discovery, recommendations, contribution flow orchestration, impact reporting, donor relationship management |
+| Payment Service | [Payments](L4-004) | Payment gateway integration, tokenisation, escrow, disbursement, refunds, reconciliation, tax receipts |
+| KYC Service | [KYC](L4-005) | Identity verification, document handling, sanctions screening, verification lifecycle |
+
+### 3.2 Shared / Platform Services
+
+| Service | Responsibilities |
+| --- | --- |
+| API Gateway | Request routing, rate limiting, authentication token validation, correlation ID injection, TLS termination |
+| Notification Service | Email, push, and in-app notification delivery; template management; delivery tracking |
+| Audit Service | Append-only event ingestion, storage, and query — see [Audit](L3-006). Event sourcing provides a natural audit trail; the Audit Service reads from the event store. |
+| Search Service | Full-text search over campaigns, projects, and public profiles — backed by PostgreSQL full-text search over CQRS read models. No external search provider required. |
+| Feature Flag & Analytics Service (PostHog) | Feature flags, product analytics, and web analytics — see Section 9 |
+| Secrets Management Service | Secret storage, injection, and rotation — see Section 8 |
+
+### 3.3 External Integration Adapters
+
+Per [Engineering Standard](L2-002), Section 2.4, every external dependency is accessed through an internal adapter interface.
+
+| Adapter | External Provider | Consuming Services |
+| --- | --- | --- |
+| Payment Gateway Adapter | Stripe (per L3-008) | Payment Service |
+| KYC Provider Adapter | Veriff (stubbed/mocked for local demo) | KYC Service |
+| Email Delivery Adapter | AWS SES | Notification Service |
+| Object Storage Adapter | AWS S3 (per L3-008 — S3 used for frontend assets, audit cold storage, and document uploads) | KYC Service, Campaign Service |
+
+Each adapter exposes an internal interface contract.
+The concrete provider implementation is swappable without changes to consuming code.
+
+---
+
+## 4. Data Model Overview
+
+### 4.1 Data Ownership
+
+Each domain service owns its data store.
+No service reads from or writes to another service's data store directly.
+Cross-service data access occurs only through published API contracts or consumed events.
+
+Detailed data classification, retention, and lifecycle policies are defined in [Data Management](L3-004).
+
+### 4.2 Data Access Layer
+
+Per [Engineering Standard](L2-002), Section 1.2, all data access goes through a data access layer that enforces:
+
+- Parameterised queries exclusively (no string concatenation in query construction).
+- Access control validation (the calling identity has permission to access the requested resource).
+- Structured logging of all data access operations (resource ID, action, actor — never raw PII).
+
+The data access layer uses raw SQL via pg (parameterised queries) — no ORM or query builder.
+
+### 4.3 Data Model Diagram
+
+Data model will emerge as domain requirements are discovered and implemented.
+Entity-relationship diagram to be added once core aggregates are stabilised.
+
+---
+
+## 5. Infrastructure & Deployment Topology
+
+### 5.1 Environment Topology
+
+Per [Engineering Standard](L2-002), Section 7.1, three environments exist with structural parity:
+
+| Environment | Purpose | Scale | Data |
+| --- | --- | --- | --- |
+| Development | Local and CI-based development and testing | Minimal replicas | Synthetic / seeded |
+| Staging | Pre-production validation, integration testing, performance testing | Reduced replicas | Synthetic, representative volume |
+| Production | Live traffic | Full scale | Real |
+
+All environments share the same service topology, network layout, and configuration shape.
+Differences are limited to scale, data, and secrets.
+
+### 5.2 Infrastructure Diagram
+
+Infrastructure diagram to be added once deployment topology is stabilised.
+Will cover: edge layer, API gateway, services, data stores, event bus, external integrations, and observability stack.
+
+### 5.3 Deployment Pipeline
+
+Per [Engineering Standard](L2-002), Section 7.4:
+
+- Every deployment is automated from merge-to-main through to production, with explicit approval gates per Section 4.5 of the [Engineering Standard](L2-002).
+- Every deployment is reproducible: same commit hash and configuration produces identical artefacts.
+- Rollback to the previous version is possible within 15 minutes with no data loss.
+- Database migrations are backward-compatible: the previous application version must function against the new schema.
+
+The CI/CD platform is recorded in the Technology Selection Registry (Section 8).
+
+### 5.4 Container & Orchestration Strategy
+
+- **Containerisation**: Single Docker container deployed to AWS ECS Fargate.
+- **Deployment unit**: All domain services run within one deployment unit (monolithic deployment, modular internal architecture via hexagonal architecture per [Tech Stack](L3-008)).
+- **Load balancing**: Behind an Application Load Balancer (ALB) for health checks, TLS termination, and request routing.
+- **Frontend**: Served via CloudFront CDN with S3 origin (per [Tech Stack](L3-008)).
+
+---
+
+## 6. Inter-Service Communication
+
+### 6.1 Synchronous Communication
+
+Synchronous (request/response) communication is used when the caller requires an immediate response to proceed.
+
+- **Protocol**: REST over HTTPS.
+- **Service discovery**: Not required — all services run within a single deployment unit. If services are split in the future, ECS Service Connect (AWS Cloud Map) is the natural fit.
+- **Timeout and retry policy**: Every synchronous call must define a timeout.
+Retry policies must use exponential backoff with jitter.
+Circuit breaker patterns are defined in [Reliability](L3-003).
+
+#### API Versioning
+
+Per [Engineering Standard](L2-002), Section 5.1, all APIs are versioned from day one.
+
+- **Scheme**: URL path versioning (`/v1/resource`).
+- **Deprecation periods**: Minimum 90 days for external APIs, 30 days for internal APIs per [Engineering Standard](L2-002), Section 5.1.
+
+#### Error Response Format
+
+Per [Engineering Standard](L2-002), Section 5.3, all APIs use a consistent error response format:
+
+```json
+{
+  "error": {
+    "code": "<MACHINE_READABLE_ERROR_CODE>",
+    "message": "<Human-readable message suitable for display>",
+    "correlation_id": "<Request correlation ID>",
+    "details": {}
+  }
+}
+```
+
+- `code`: A stable, machine-readable identifier (e.g., `CAMPAIGN_NOT_FOUND`, `INSUFFICIENT_FUNDS`). Not an HTTP status code.
+- `message`: Follows voice-in-product patterns from [Brand Standard](L2-001).
+- `correlation_id`: The correlation ID assigned at the edge per [Engineering Standard](L2-002), Section 6.2.
+- `details`: Optional structured context to help the caller understand and resolve the error. Must never contain internal implementation details or sensitive data.
+
+### 6.2 Asynchronous Communication
+
+Asynchronous (event-driven) communication is used when:
+
+- The caller does not need an immediate response.
+- Multiple consumers need to react to the same event.
+- Temporal decoupling improves system resilience.
+
+#### CQRS & Event Sourcing
+
+- **Pattern**: Commands mutate state by appending events to the event store. Queries read from materialised read models. This separation allows independent scaling and optimisation of write and read paths.
+- **Event Store**: PostgreSQL (Aurora) — events are append-only rows in a dedicated events table per aggregate. No separate message broker is required.
+- **Event schema**: All events follow a common envelope:
+
+```json
+{
+  "event_id": "<UUID>",
+  "event_type": "<DOMAIN>.<ACTION>",
+  "timestamp": "<ISO 8601>",
+  "correlation_id": "<Request correlation ID>",
+  "source_service": "<Emitting service name>",
+  "payload": {}
+}
+```
+
+- **Read Model Populators**: Pull events from the event store and project them into read-optimised views (PostgreSQL tables or materialised views). All populators are idempotent — replaying events produces the same read model state.
+- **Process Managers**: Coordinate cross-aggregate workflows by consuming events and issuing commands. Process managers maintain their own state and are idempotent.
+- **Delivery guarantees**: At-least-once. All consumers are idempotent. Consumption is pull-based — populators and process managers poll the event store for new events using a stored checkpoint.
+- **Schema evolution**: Events follow backward-compatible evolution rules mirroring [Engineering Standard](L2-002), Section 5.2 (new fields may be added; existing fields must not be removed or changed).
+
+### 6.3 Service Identity & Authentication
+
+Per [Engineering Standard](L2-002), Section 1.5, every service-to-service call is authenticated.
+
+- **Mechanism**: Not applicable — single deployment unit, all inter-service calls are in-process. If services are split in the future, JWT service tokens are recommended, aligning with existing Clerk/OIDC infrastructure.
+- Each service has a unique identity.
+No service impersonates another.
+- Authorisation policies define which services can call which endpoints.
+
+---
+
+## 7. Architecture Decision Record (ADR) Process
+
+Per [Engineering Standard](L2-002), Section 3.1, architectural decisions affecting multiple services follow a structured ADR process.
+
+### 7.1 When an ADR Is Required
+
+- Introducing a new service or removing an existing one.
+- Changing inter-service communication patterns or protocols.
+- Selecting or replacing a technology in the Technology Selection Registry.
+- Modifying service boundaries or data ownership.
+- Any decision that changes the interface contract between two or more services.
+
+### 7.2 ADR Template
+
+Each ADR is stored in `specs/adrs/` with the filename `NNNN-<short-title>.md`:
+
+```markdown
+# ADR-NNNN: <Title>
+
+> **Status**: Proposed | Accepted | Deprecated | Superseded by ADR-XXXX
+> **Date**: <YYYY-MM-DD>
+> **Deciders**: <list of people involved>
+
+## Context
+
+What is the issue or decision we need to make? What forces are at play?
+
+## Decision
+
+What is the decision and why?
+
+## Consequences
+
+What are the positive, negative, and neutral consequences of this decision?
+
+## Compliance
+
+Which spec constraints (L2-002 sections, L3 constraints) does this decision satisfy or affect?
+```
+
+### 7.3 ADR Lifecycle
+
+1. **Proposed**: Author creates the ADR and opens a PR. The PR description links to the ADR.
+1. **Review**: Peer review from at least one engineer outside the proposing team, per [Engineering Standard](L2-002), Section 3.1.
+1. **Accepted**: Merged to main. The decision is binding.
+1. **Superseded**: A new ADR explicitly supersedes this one. The old ADR is updated with a pointer to the new one.
+
+---
+
+## 8. Technology Selection Registry
+
+All approved technology choices are recorded here.
+New entries require a vendor evaluation per [Engineering Standard](L2-002), Section 2.5 and an ADR per Section 7.
+
+| Category | Technology | ADR | Notes |
+| --- | --- | --- | --- |
+| Primary language(s) | TypeScript (Node.js 22.x LTS) | — | Per L3-008 |
+| Web framework | Express 5.x | — | Per L3-008 |
+| ORM / query builder | pg (raw SQL, parameterised queries) | — | Must enforce parameterised queries per [Engineering Standard](L2-002), Section 1.2. Per L3-008 |
+| API documentation | OpenAPI 3.1 (swagger-jsdoc + swagger-ui-express) | — | Machine-readable, validated against implementation per [Engineering Standard](L2-002), Section 5.5 |
+| Event bus / message broker | PostgreSQL event store (CQRS/Event Sourcing — no separate broker) | — | Events are append-only rows in Aurora PostgreSQL. See Section 6.2. |
+| Container runtime | Docker | — | Per L3-008 |
+| Orchestration platform | AWS ECS Fargate | — | Per L3-008 |
+| CI/CD platform | GitHub Actions | — | Must support automated, reproducible deployments per [Engineering Standard](L2-002), Section 7.4. Per L3-008 |
+| Secrets management | AWS Secrets Manager (env vars for local dev) | — | Runtime injection and rotation per [Engineering Standard](L2-002), Sections 1.3 and 7.3 |
+| Feature flag service | PostHog | — | Feature flags, product analytics, and web analytics. Runtime-configurable without deployment per [Engineering Standard](L2-002), Section 7.2 |
+| Monitoring / observability | PostHog (product analytics), CloudWatch + Pino (developer observability) | — | PostHog for user-facing analytics; CloudWatch for infrastructure metrics and alerts; Pino for structured application logging per [Engineering Standard](L2-002), Section 6 |
+| Payment gateway | Stripe | — | Per L3-008. See [Payments](L4-004) |
+| KYC provider | Veriff (stubbed/mocked for local demo) | — | See [KYC](L4-005) |
+| Email delivery | AWS SES | — | Transactional and notification emails |
+| Search engine | PostgreSQL full-text search (via CQRS read models) | — | No external provider — search served by dedicated read models |
+| Object storage | AWS S3 | — | Per L3-008 (CloudFront S3 origin, audit cold storage) |
+| Database(s) | AWS Aurora PostgreSQL | — | Per-service data ownership. Per L3-008 |
+
+---
+
+## 9. Feature Flag Framework
+
+Per [Engineering Standard](L2-002), Sections 4.5 and 7.2:
+
+- Feature flags are the default deployment mechanism for user-facing changes.
+- Feature flags are runtime-configurable without deployment.
+- Feature flags are managed through PostHog (not environment variables).
+
+### 9.1 Flag Lifecycle
+
+| Stage | Description |
+| --- | --- |
+| Created | Flag registered in the feature flag service with a default-off state |
+| Development | Flag used to gate in-progress work; enabled only in development and staging |
+| Rollout | Flag enabled incrementally in production (percentage-based, user-segment, or allow-list) |
+| Fully enabled | Flag enabled for all users; code path without the flag is verified as unused |
+| Removed | Flag and conditional code removed in a follow-up PR; dead code is not acceptable |
+
+### 9.2 Flag Naming Convention
+
+Flags use kebab-case keys following the pattern `<domain>-<feature>`:
+
+- `campaign-milestone-tracking`
+- `donor-impact-dashboard`
+- `payment-crypto-support`
+
+### 9.3 Flag Ownership
+
+Every flag has an owner (team or individual) and a planned removal date.
+Flags that exceed their planned lifetime are flagged in a regular cleanup review.
+
+---
+
+## 10. Linting & Formatting
+
+Per [Engineering Standard](L2-002), Section 4.1, all code passes automated linting and formatting checks before review.
+Formatting is never a review discussion — it is automated.
+
+### 10.1 Rulesets Per Language
+
+| Language | Linter | Formatter | Configuration |
+| --- | --- | --- | --- |
+| TypeScript | ESLint (flat config) | Prettier | `eslint.config.js`, `.prettierrc` |
+| Markdown | markdownlint-cli2 | — | `.markdownlint.jsonc` (per L3-007) |
+
+### 10.2 Enforcement
+
+- Linting and formatting checks run in CI on every PR per [Engineering Standard](L2-002), Section 4.4.
+- Pre-commit hooks are available for local development but CI is the authoritative gate.
+- Auto-formatting is applied on save in recommended IDE configurations.
+
+---
+
+## 11. Interface Contracts
+
+This spec shares boundaries with every other L3 spec and several L4 specs.
+
+### 11.1 Architecture <> Security (L3-002)
+
+- This spec defines the service topology and communication patterns.
+[Security](L3-002) defines the threat model, authentication/authorisation mechanisms, and encryption implementations that operate within this topology.
+- This spec defines the API Gateway as the TLS termination and token validation point.
+[Security](L3-002) defines the token format, validation rules, and MFA requirements.
+- Service identity mechanism (Section 6.3) is jointly owned: this spec defines the pattern; [Security](L3-002) defines the credentials and trust model.
+
+### 11.2 Architecture <> Reliability (L3-003)
+
+- This spec defines the service topology and deployment pipeline.
+[Reliability](L3-003) defines availability targets, failover strategies, circuit breaker configurations, and health check contracts that apply to every service in this topology.
+- The deployment rollback requirement (15 minutes, Section 5.3) is jointly owned with [Reliability](L3-003).
+
+### 11.3 Architecture <> Data Management (L3-004)
+
+- This spec establishes per-service data ownership (Section 4.1).
+[Data Management](L3-004) defines the data classification scheme, retention policies, anonymisation rules, and migration strategies that apply to each service's data store.
+- The data access layer (Section 4.2) enforces parameterised queries and access logging.
+[Data Management](L3-004) defines what data is classified at each level and the access rules per classification.
+
+### 11.4 Architecture <> Frontend Standards (L3-005)
+
+- This spec defines the API Gateway and backend service contracts that the frontend consumes.
+[Frontend Standards](L3-005) defines the frontend architecture, component standards, and performance budgets for the client layer.
+- The error response format (Section 6.1) is consumed by the frontend.
+[Frontend Standards](L3-005) defines how errors are presented to users, implementing the voice-in-product patterns from [Brand Standard](L2-001).
+
+### 11.5 Architecture <> Audit (L3-006)
+
+- This spec defines the Audit Service as a shared platform service (Section 3.2).
+[Audit](L3-006) defines the audit event schema, immutability guarantees, retention policies, and access controls.
+- The event envelope (Section 6.2) provides the base structure.
+[Audit](L3-006) extends this with audit-specific fields and ingestion contracts.
+
+---
+
+## 12. Change Log
+
+| Date | Version | Author | Summary |
+| --- | --- | --- | --- |
+| March 2026 | 0.1 | — | Initial stub. Service boundaries, communication patterns, infrastructure topology, ADR process, technology registry, feature flags, linting. |
+| March 2026 | 0.2 | — | Backfilled Technology Selection Registry with resolved choices from L3-008 (TypeScript, Express 5, pg, Docker, ECS Fargate, GitHub Actions, Aurora PostgreSQL). Resolved Open Questions 1, 7, 8, 9. Added L3-008 dependency. |
+| March 2026 | 0.3 | — | Resolved all remaining open questions (2–6, 10–12). Established CQRS/Event Sourcing as core pattern (Section 6.2). Selected REST over HTTPS with URL-path versioning (Section 6.1). Selected PostHog for feature flags, product analytics, and web analytics (Sections 3.2, 8, 9). CloudWatch + Pino for developer observability (Section 8). Service discovery and service-to-service auth noted as not applicable for single deployment unit (Sections 6.1, 6.3). Filled container & orchestration strategy (Section 5.4). |

--- a/specs/tech/audit.md
+++ b/specs/tech/audit.md
@@ -1,0 +1,362 @@
+# Audit Logging & Transparency
+
+> **Spec ID**: L3-006
+> **Version**: 0.2
+> **Status**: Approved
+> **Rate of Change**: Sprint-level / tech decisions
+> **Depends On**: L1-001 (Product Vision & Mission), L2-002 (Engineering Standard), L3-001 (Architecture), L3-002 (Security)
+> **Depended On By**: L4-002 (Campaign), L4-004 (Payments), L4-005 (KYC)
+
+---
+
+## 1. Purpose
+
+> **Local demo scope**: The audit event schema, event categories, logging trigger rules, and the PostgreSQL event store integration are **real** — audit events are written as part of the CQRS/Event Sourcing pattern in the local demo. Tamper detection (hash chains), tiered storage, anomaly detection, regulatory reporting processes, and the access grant workflow are theatre. The local demo writes audit events to PostgreSQL with no archival or detection pipeline.
+
+This spec governs the audit logging architecture for Mars Mission Fund: what gets logged, how audit events are structured, how they are stored immutably, who can access them, how long they are retained, and how they support regulatory compliance and anomaly detection.
+
+This spec **implements**:
+
+- The "Transparency as Currency" principle from the [Product Vision & Mission](L1-001).
+- The logging and auditability invariants from [Engineering Standard](L2-002), Section 1.7.
+- The structured logging baseline from [Engineering Standard](L2-002), Section 6.1.
+
+This spec does **not** cover:
+
+- Operational logging for debugging and performance monitoring — that is the observability baseline in [Engineering Standard](L2-002), Section 6.
+- Alerting thresholds and incident response escalation — those are defined in [Reliability](L3-003).
+- Data classification and general retention policies — those are defined in [Data Management](L3-004). This spec references that classification scheme and defines audit-specific retention periods.
+- Application-level business metrics and analytics — those belong in individual L4 domain specs.
+
+---
+
+## 2. Inherited Constraints
+
+From [Engineering Standard](L2-002):
+
+- **Section 1.7 — Logging & Auditability**: Every state mutation is logged with timestamp, actor identity, action performed, and affected resource. Logs are append-only and immutable. No mechanism exists to delete or modify audit log entries. Sensitive data is never logged.
+- **Section 6.1 — Structured Logging**: All logs are JSON-formatted with mandatory fields: `timestamp`, `level`, `correlation_id`, `service`, `message`, `context`.
+- **Section 6.2 — Correlation IDs**: Every request is assigned a unique correlation ID at the edge that propagates through all services and log entries.
+- **Section 1.2 — Data Access**: All queries use parameterised queries. Audit log queries are no exception.
+- **Section 1.3 — Secrets Management**: Secrets never appear in log output.
+- **Section 1.1 — Encryption**: Audit data is encrypted at rest (AES-256) and in transit (TLS 1.3).
+
+From [Security](L3-002):
+
+- Audit log access is governed by the RBAC model defined in [Security](L3-002).
+- Tamper detection mechanisms must align with the integrity controls defined in [Security](L3-002).
+
+---
+
+## 3. Audit Event Schema
+
+Audit events extend the structured logging baseline from [Engineering Standard](L2-002), Section 6.1 with audit-specific fields.
+
+### 3.1 Base Fields (inherited from L2-002 Section 6.1)
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `timestamp` | string (ISO 8601 with timezone) | When the event occurred |
+| `level` | string | Always `AUDIT` for audit events (distinct from operational log levels) |
+| `correlation_id` | string (UUID) | Request correlation ID from the edge |
+| `service` | string | Name of the emitting service |
+| `message` | string | Human-readable description of the auditable action |
+| `context` | object | Structured metadata (see audit-specific fields below) |
+
+### 3.2 Audit-Specific Fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `event_type` | string (enum) | Yes | Category of audit event (see Section 4) |
+| `actor_id` | string | Yes | Identity of the user or service principal that performed the action |
+| `actor_type` | string (enum) | Yes | `user`, `service`, `system`, `admin` |
+| `action` | string | Yes | The specific action performed (e.g., `campaign.create`, `payment.disburse`, `user.login`) |
+| `resource_type` | string | Yes | Type of resource affected (e.g., `campaign`, `payment`, `account`) |
+| `resource_id` | string | Yes | Identifier of the affected resource |
+| `outcome` | string (enum) | Yes | `success`, `failure`, `denied` |
+| `ip_address` | string | Conditional | Client IP address (required for user-initiated events, omitted for system events) |
+| `user_agent` | string | Conditional | Client user agent (required for user-initiated events) |
+| `previous_state` | object | Conditional | Snapshot of relevant fields before the mutation (required for state changes) |
+| `new_state` | object | Conditional | Snapshot of relevant fields after the mutation (required for state changes) |
+| `reason` | string | Conditional | Reason for the action, where applicable (e.g., denial reason, admin override justification) |
+| `metadata` | object | No | Additional structured context specific to the event type |
+
+### 3.3 Sensitive Data Rules
+
+Per [Engineering Standard](L2-002), Section 1.7: sensitive data must never appear in audit log entries.
+
+- `previous_state` and `new_state` must use resource identifiers, not raw personal data.
+- Fields containing PII, financial data, or credentials must be redacted or replaced with tokenised references before logging.
+- The data classification scheme in [Data Management](L3-004) defines what constitutes sensitive data.
+
+**Redaction strategy: Reference-only.** Audit events store resource identifiers (e.g., `actor_id`, `resource_id`), never raw PII. This aligns naturally with the CQRS/Event Sourcing pattern established in [Architecture](L3-001), Section 6.2 — events already reference aggregates by ID. When human-readable details are needed (e.g., for an investigation), the audit query service joins against current read models at query time. Sensitive fields such as email, name, and address are never present in the event payload.
+
+---
+
+## 4. What Gets Logged
+
+Per [Engineering Standard](L2-002), Section 1.7: every state mutation in the system is logged.
+Beyond state mutations, the following event categories are mandatory.
+
+### 4.1 Event Categories
+
+| Category | Event Type | Examples |
+| -------- | ---------- | -------- |
+| **Authentication** | `auth` | Login success/failure, logout, MFA challenge/success/failure, session creation/expiry, token refresh, password reset request/completion |
+| **Authorisation** | `authz` | Permission check granted/denied, role assignment/removal, privilege escalation, access to restricted resources |
+| **State Mutation** | `mutation` | Any create, update, or delete operation on a domain entity (campaign, payment, account, KYC record) |
+| **Data Access** | `access` | Read access to sensitive data (PII, financial records, KYC documents) — not every read, only reads of classified-sensitive resources |
+| **Configuration Change** | `config` | Feature flag changes, environment variable updates, service configuration changes, deployment events |
+| **Admin Action** | `admin` | Any action performed with elevated privileges — user impersonation, manual overrides, data corrections, bulk operations |
+| **Financial Event** | `financial` | Payment initiation, payment completion, refund, escrow hold/release, disbursement, reconciliation |
+| **KYC Event** | `kyc` | Document upload, verification status change, sanctions screening result, manual review decision |
+| **System Event** | `system` | Service startup/shutdown, scheduled job execution, automated retention enforcement, audit log export |
+
+### 4.2 Logging Trigger Rules
+
+- **State mutations**: Logged automatically by the data access layer. Application code does not manually emit audit events for state changes — the data access layer defined in [Engineering Standard](L2-002), Section 1.2 handles this.
+- **Authentication and authorisation**: Logged by the auth middleware defined in [Security](L3-002).
+- **Data access**: Logged by the data access layer for any query touching resources classified as sensitive in [Data Management](L3-004).
+- **Admin actions**: Logged explicitly by the admin tooling layer. All admin actions require a `reason` field.
+- **Financial events**: Logged by the payments integration layer defined in [Payments](L4-004). Both the initiation and the outcome of every financial operation are logged as separate events.
+
+---
+
+## 5. Immutability Guarantees
+
+Audit logs are the foundation of trust and regulatory compliance.
+Their integrity is non-negotiable.
+
+### 5.1 Append-Only Storage
+
+- Audit events are written to an append-only store.
+- No API, tool, or administrative interface permits modification or deletion of audit log entries.
+- The storage layer must enforce append-only semantics at the infrastructure level, not just at the application level.
+
+**Storage technology: Immutable event stream in PostgreSQL (Aurora).** Audit events are stored as append-only rows in the same PostgreSQL event store used by the CQRS/Event Sourcing infrastructure ([Architecture](L3-001), Section 6.2). Delete and update operations are prevented by database-level row security policies and the application data access layer. This reuses existing infrastructure, keeps the stack simple, and provides full SQL query capabilities over audit data.
+
+### 5.2 Tamper Detection
+
+- Every audit event includes a cryptographic hash that chains it to the previous event in the same stream (hash chain).
+- Periodic integrity verification runs to detect gaps, out-of-order entries, or hash chain breaks.
+- Integrity verification failures trigger an immediate security alert through the incident response process defined in [Reliability](L3-003).
+
+**Hash chain: SHA-256, per aggregate stream, daily batch verification.** Each audit event includes a `previous_hash` field containing the SHA-256 hash of the preceding event in the same aggregate stream. A daily scheduled job verifies chain integrity across all streams and raises a security alert on any gap, reorder, or hash mismatch. This balances tamper detection strength with low write overhead — suitable for a workshop-scale system.
+
+### 5.3 Backup and Redundancy
+
+- Audit logs are replicated to a geographically separate location.
+- Backup copies are subject to the same immutability and access control guarantees as primary copies.
+- Backup integrity is verified on a defined schedule.
+
+---
+
+## 6. Retention Periods
+
+Retention periods are defined by event category and regulatory requirement.
+General data retention policies are defined in [Data Management](L3-004); this section defines audit-specific retention that may exceed general retention periods due to regulatory obligations.
+
+### 6.1 Retention Schedule
+
+| Event Category | Minimum Retention | Rationale |
+| -------------- | ----------------- | --------- |
+| Financial events | 7 years | PCI DSS, Australian tax record-keeping requirements |
+| KYC events | 7 years after relationship end | AML/CTF Act record-keeping obligations |
+| Authentication events | 2 years | Security investigation window |
+| Authorisation events | 2 years | Security investigation window |
+| Data access events | 2 years | GDPR data access audit trail |
+| Admin actions | 7 years | Regulatory and compliance audit trail |
+| Configuration changes | 2 years | Change management audit trail |
+| State mutations (financial entities) | 7 years | Aligned with financial event retention |
+| State mutations (non-financial entities) | 2 years | Operational audit trail |
+| System events | 1 year | Operational diagnostics |
+
+### 6.2 Retention Enforcement
+
+- Retention enforcement is automated. No manual deletion of audit data is permitted.
+- When retention periods expire, data is purged through an automated process that itself is audit-logged (event type: `system`).
+- Purge operations must respect legal hold requirements — if audit data is subject to a legal hold, retention is extended indefinitely until the hold is lifted.
+
+**Retention enforcement: Tiered storage.** Audit data moves through tiers based on age: hot (PostgreSQL, last 90 days — immediately queryable), cold (S3 export, 90 days to end of retention — queryable with higher latency), purge (automated deletion after retention period expires). Tier transitions and purge operations are executed by scheduled jobs and are themselves audit-logged. Legal holds suspend purge for affected data until the hold is lifted.
+
+---
+
+## 7. Access Controls on Audit Data
+
+### 7.1 Principles
+
+- **Separation of duty**: The people and services whose actions are audited must not be able to modify or delete audit records.
+- **Least privilege**: Access to audit data is restricted to roles with a demonstrated need.
+- **Audit the auditors**: Access to audit data is itself audited (event type: `access`).
+
+### 7.2 Access Roles
+
+| Role | Read Access | Write Access | Notes |
+| ---- | ----------- | ------------ | ----- |
+| Application services | No direct read | Append only (via audit logging SDK) | Services emit audit events but cannot query them |
+| Engineers (on-call / incident response) | Scoped read (own service, limited time window) | None | Access granted per-incident, time-limited, logged |
+| Security team | Full read | None | For security investigations and compliance audits |
+| Compliance / audit team | Full read | None | For regulatory reporting and external audit support |
+| Platform administrators | Full read | None | No one has write/delete access — by design |
+| External auditors | Scoped read (via export) | None | Read access via exported reports, not direct system access |
+
+### 7.3 Access Mechanism
+
+- Audit data is queried through a dedicated audit query service, not through direct database access.
+- The audit query service enforces authentication, authorisation, and access logging for every query.
+- Time-limited access grants for incident response are managed through the access control system defined in [Security](L3-002).
+
+**Access grant workflow: Request AWS Prod Access.**
+
+- **Read access**: No approval required. All audit query service reads are logged.
+- **Elevated access** (access secrets or write to audit-adjacent systems): Requires automated approval via the access request system.
+- **Maximum grant duration**: 8 hours, automatically revoked.
+- **Implementation note**: This workflow is out of scope for the local-only demo. The design is recorded here for production readiness.
+
+---
+
+## 8. Regulatory Reporting
+
+### 8.1 PCI DSS Audit Trail Requirements
+
+Per PCI DSS requirements (applicable via [Payments](L4-004) and [Security](L3-002)):
+
+- All access to cardholder data environments is logged.
+- Audit trails are retained for at least one year, with a minimum of three months immediately available for analysis.
+- Audit trail entries include user identification, type of event, date and time, success/failure indication, origination of event, and identity or name of affected data/system/resource.
+- Audit trails are secured so they cannot be altered.
+- Audit trails are reviewed at least daily (automated review via anomaly detection — see Section 9).
+
+**PCI DSS scope: SAQ-A.** Mars Mission Fund does not store, process, or transmit credit card PANs — card processing is fully outsourced to the payment gateway. Under SAQ-A, PCI DSS audit trail requirements are minimal for card data. However, PII is stored and payment system integrations exist, so GDPR and Australian Privacy Act audit obligations (Sections 8.2 and 8.3) still apply in full. All payment events (initiation, completion, refund, disbursement) are audit-logged as `financial` events referencing tokenised payment identifiers, never raw card data.
+
+### 8.2 GDPR Data Access Logs
+
+Per GDPR requirements (applicable via [Security](L3-002) and [Data Management](L3-004)):
+
+- All access to personal data is logged.
+- Logs support responding to Data Subject Access Requests (DSARs) — the system must be able to produce a complete record of who accessed a data subject's personal data and when.
+- Data access logs themselves are subject to GDPR retention limits — they must not be retained longer than necessary for their purpose, but must satisfy the minimum audit retention periods above.
+
+### 8.3 Australian Privacy Act
+
+- Audit logs support demonstrating compliance with Australian Privacy Principles (APPs).
+- Access to audit data containing personal information of Australian residents is subject to the same data handling requirements as the underlying personal data.
+
+**Australian Privacy Act: No additional requirements beyond GDPR handling.** No specific differences have been identified that require separate audit handling. The existing GDPR-aligned audit controls (data access logging, DSAR support, retention limits) satisfy Australian Privacy Principles. This will be revisited if specific regulatory guidance emerges.
+
+---
+
+## 9. Anomaly Detection
+
+Audit logs are not just a compliance requirement — they are an active security signal.
+The system must detect suspicious patterns in near-real-time and surface them to the security team.
+
+### 9.1 Detection Baselines
+
+The following patterns must be detected and alerted on:
+
+| Pattern | Description | Severity |
+| ------- | ----------- | -------- |
+| Repeated authentication failures | Multiple failed login attempts for the same account within a time window | High |
+| Unusual transaction patterns | Transactions outside normal volume, frequency, or amount ranges for a given account or campaign | High |
+| Privilege escalation attempts | Authorisation denials followed by successful access to the same resource (potential bypass) | Critical |
+| Off-hours admin actions | Administrative actions performed outside normal business hours | Medium |
+| Bulk data access | Unusually large volumes of sensitive data reads by a single actor in a short period | High |
+| Geographic anomalies | Authentication or financial actions from unexpected geographic locations | Medium |
+| Configuration changes without change tickets | Configuration or feature flag changes that don't correlate with approved change records | High |
+
+### 9.2 Detection Architecture
+
+- Anomaly detection operates on the audit event stream in near-real-time.
+- Detection rules are configurable and versioned alongside application code.
+- Alerts are routed through the alerting infrastructure defined in [Reliability](L3-003).
+- False positive rates are tracked and detection rules are tuned iteratively.
+
+**Anomaly detection approach: Rule-based.** Explicit threshold rules as defined in the detection baselines table (Section 9.1). Rules are simple, transparent, and easy to tune. Statistical baseline detection is unnecessary for a workshop-scale system and adds implementation complexity without proportional benefit. Implementation is out of scope for the local-only demo; the rules are recorded here for production readiness.
+
+### 9.3 Response Integration
+
+- Anomaly detection alerts include sufficient context for the security team to begin investigation without querying additional systems.
+- Critical-severity anomalies trigger automated containment actions as defined in the incident response process in [Security](L3-002) (e.g., temporary account lockout after repeated auth failures).
+
+---
+
+## 10. Audit Log Query Interface
+
+### 10.1 Query Capabilities
+
+The audit query service must support:
+
+- **Filtering** by any combination of: time range, actor ID, actor type, event type, action, resource type, resource ID, outcome, correlation ID.
+- **Full-text search** on the `message` and `reason` fields.
+- **Aggregation** — counts and summaries grouped by any filterable dimension (e.g., "count of failed logins by actor in the last 24 hours").
+- **Export** to structured formats (JSON, CSV) for external audit tool consumption and regulatory reporting.
+- **Correlation trace reconstruction** — given a correlation ID, return the complete ordered sequence of audit events across all services for that request.
+
+### 10.2 Performance Requirements
+
+- Queries against recent data (last 30 days) must return results within seconds (specific SLA to be defined in [Reliability](L3-003)).
+- Queries against archived data (beyond 30 days) may have higher latency but must complete within a defined timeout.
+- The query interface must not impact the write performance of the audit logging pipeline.
+
+**Query latency SLAs:**
+
+- **Hot tier (last 90 days, PostgreSQL)**: Sub-second response times for filtered queries. This is the primary query target for investigations and operational use.
+- **Cold tier (90 days+, S3 export)**: Up to 5 minutes for query results. Acceptable for compliance reporting and historical investigations.
+- **Data freshness**: Audit events are queryable within 5 minutes of occurrence (see OQ-010). For most operations, freshness is sub-second due to the event sourcing pull-based model, but the 5-minute SLA accommodates SDK batching and read model projection delay.
+
+The tiered storage boundaries (90-day hot/cold split) align with PCI DSS requirements for three months of immediately available audit data (Section 8.1).
+
+### 10.3 Audit Logging SDK
+
+Application services emit audit events through a shared SDK or library, not through direct writes to the audit store.
+
+The SDK must:
+
+- Enforce the audit event schema (Section 3).
+- Automatically populate base fields (timestamp, correlation ID, service name) from the request context.
+- Handle failures gracefully — audit logging failures must not cause the originating operation to fail, but must trigger an alert.
+- Buffer and batch writes for performance, with a maximum acceptable delay before events reach the audit store.
+
+**Maximum ingestion delay: 5 minutes.** Audit events must be queryable in the audit store within 5 minutes of the auditable action occurring. In practice, the event sourcing model delivers sub-second freshness for most events. The 5-minute ceiling accommodates SDK write batching and any transient delays in read model projection. Anomaly detection rules (Section 9) operate within this window.
+
+---
+
+## 11. Interface Contracts
+
+### 11.1 Interface with Architecture (L3-001)
+
+- The audit logging infrastructure (storage, query service, event streaming) is deployed as part of the platform architecture defined in [Architecture](L3-001).
+- The audit event stream is a shared infrastructure component, not owned by any single domain service.
+
+### 11.2 Interface with Security (L3-002)
+
+- [Security](L3-002) defines the RBAC roles and permission model that governs access to audit data (Section 7.2 of this spec).
+- [Security](L3-002) defines the incident response process that consumes anomaly detection alerts (Section 9.3 of this spec).
+- Tamper detection mechanisms (Section 5.2) align with the integrity controls in [Security](L3-002).
+
+### 11.3 Interface with Data Management (L3-004)
+
+- [Data Management](L3-004) defines the data classification scheme that determines which data access events are audit-logged (Section 4.1, "Data Access" category).
+- [Data Management](L3-004) defines general retention policies; this spec defines audit-specific retention that may exceed those policies (Section 6).
+- Sensitive data redaction rules (Section 3.3) reference the classification in [Data Management](L3-004).
+
+### 11.4 Interface with Reliability (L3-003)
+
+- [Reliability](L3-003) defines the alerting infrastructure that routes anomaly detection alerts (Section 9.2).
+- [Reliability](L3-003) defines the SLAs that govern audit query performance targets (Section 10.2).
+
+### 11.5 Interface with Domain Specs (L4-002, L4-004, L4-005)
+
+- **Campaign (L4-002)**: Campaign lifecycle state changes (submission, review, approval, funding milestones, completion, failure) are audit-logged as `mutation` and `financial` events. The campaign spec defines which state transitions are auditable and references this spec for the logging mechanism.
+- **Payments (L4-004)**: All payment operations (initiation, completion, refund, escrow, disbursement) are audit-logged as `financial` events. The payments spec defines the specific payment events and references this spec for PCI DSS audit trail compliance.
+- **KYC (L4-005)**: All identity verification events (document upload, verification result, sanctions screening, manual review decision) are audit-logged as `kyc` events. The KYC spec defines the specific KYC events and references this spec for AML/CTF record-keeping compliance.
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| ---- | ------- | ------ | ------- |
+| March 2026 | 0.1 | — | Initial stub. Audit event schema, logging categories, immutability guarantees, retention schedule, access controls, regulatory reporting (PCI DSS, GDPR, Australian Privacy Act), anomaly detection baselines, query interface, and audit logging SDK. |
+| March 2026 | 0.2 | — | Resolved all 10 open questions. Established reference-only redaction strategy, PostgreSQL event store (aligned with CQRS/ES from L3-001), SHA-256 hash chain with daily verification, tiered storage retention, SAQ-A PCI scope, rule-based anomaly detection, 5-minute ingestion SLA. |

--- a/specs/tech/data-management.md
+++ b/specs/tech/data-management.md
@@ -1,0 +1,385 @@
+# Data Management
+
+> **Spec ID**: L3-004
+> **Version**: 0.2
+> **Status**: Approved
+> **Rate of Change**: Sprint-level / tech decisions
+> **Depends On**: L2-002 (Engineering Standard), L3-001 (Architecture), L3-002 (Security)
+> **Depended On By**: L4-004 (domain/payments.md), L4-005 (domain/kyc.md)
+
+---
+
+## Purpose
+
+> **Local demo scope**: Data classification scheme, data access layer patterns, schema migration strategy, and the right-to-erasure workflow design are **real** — they inform the local demo's data model. Retention enforcement automation, tiered storage, backup verification, data residency, and cross-border transfer mechanisms are theatre. The local demo uses a single PostgreSQL instance with no archival pipeline.
+
+This spec governs how data is classified, stored, accessed, retained, archived, anonymised, backed up, recovered, and migrated across the Mars Mission Fund platform.
+
+**In scope**: data classification scheme, retention policies, data lifecycle management, anonymisation and pseudonymisation, backup and recovery, data access patterns and controls, schema migration strategy, and data residency.
+
+**Out of scope**:
+
+- Threat models and compliance control matrices — governed by [Security](L3-002).
+- Audit log architecture and immutability guarantees — governed by [Audit](L3-006).
+- Infrastructure topology and storage technology selection — governed by [Architecture](L3-001).
+- Backup frequency and failover mechanisms — governed by [Reliability](L3-003); this spec implements the data-specific requirements defined there.
+
+---
+
+## Inherited Constraints
+
+From [Engineering Standard](L2-002):
+
+- **Section 1.1 (Encryption)**: All sensitive data encrypted at rest using AES-256.
+  Sensitivity is defined by the classification scheme in this spec.
+- **Section 1.2 (Data Access)**: All database queries use parameterised queries or prepared statements.
+  All data access goes through a data access layer enforcing parameterisation, logging, and access control.
+- **Section 1.7 (Logging & Auditability)**: Every state mutation is logged.
+  Sensitive data is never logged — resource identifiers only.
+- **Section 6.1 (Structured Logging)**: PII, financial data, and credentials must never appear in log entries.
+- **Section 7.4 (Deployments)**: Database migrations must be backward-compatible — the previous application version must function against the new schema.
+
+From [Security](L3-002):
+
+- RBAC model and access control policies defined in L3-002 govern who can access each data classification level (see Section 5).
+- Encryption key management practices from L3-002 apply to all encryption at rest and in transit defined in this spec.
+- GDPR and Australian Privacy Act compliance requirements from L3-002 inform retention and anonymisation rules.
+
+---
+
+## 1. Data Classification Scheme
+
+All data in the Mars Mission Fund platform is classified into one of four sensitivity levels.
+Classification determines encryption requirements, access controls, retention policies, and handling rules.
+
+### 1.1 Classification Levels
+
+| Level | Definition | Encryption at Rest | Access Control | Examples (MMF Domain) |
+| --- | --- | --- | --- | --- |
+| **Public** | Data intended for public consumption.  Disclosure causes no harm. | Not required (but may be encrypted by default depending on storage layer) | No restriction | Published campaign descriptions, public campaign images, platform statistics, public project milestones |
+| **Internal** | Data used for platform operations.  Not intended for public access but not sensitive if disclosed. | Required | Authenticated users with appropriate role | Internal campaign review notes, aggregate analytics, system configuration (non-secret), campaign category metadata |
+| **Confidential** | Data whose disclosure could harm individuals or the organisation.  Includes PII and financial data. | Required (AES-256) | Role-based, need-to-know, logged access | User profiles (name, email, address), donor contribution history, campaign financial details, payout records, transaction amounts, notification preferences |
+| **Restricted** | Data whose disclosure could cause severe harm.  Subject to regulatory requirements. | Required (AES-256), additional key management controls | Strict role-based, MFA required for access, all access logged and alerted | KYC identity documents (passport, licence), bank account details, payment card tokens, authentication credentials, encryption keys, sanctions screening results |
+
+### 1.2 Classification Responsibilities
+
+- Every data entity in the system must have an assigned classification level.
+  Classification is assigned at design time and documented in the relevant L4 domain spec.
+- When data from multiple classification levels is combined (e.g., a report containing both Internal and Confidential data), the combined dataset inherits the highest classification level present.
+- Classification reviews occur when new data types are introduced or when regulatory requirements change.
+
+### 1.3 Classification Defaults
+
+If a data entity does not have an explicitly assigned classification:
+
+- Data containing any PII defaults to **Confidential**.
+- Data containing financial instruments, credentials, or identity documents defaults to **Restricted**.
+- All other data defaults to **Internal**.
+
+No data defaults to Public — public classification must be an explicit, deliberate decision.
+
+---
+
+## 2. Retention Policies
+
+Retention policies define how long data is kept before archival or deletion.
+Retention periods are driven by regulatory requirements, business needs, and the principle of data minimisation — we do not retain data longer than necessary.
+
+### 2.1 Retention Schedule
+
+| Data Type | Classification | Active Retention | Archive Retention | Total Retention | Regulatory Driver |
+| --- | --- | --- | --- | --- | --- |
+| KYC identity documents | Restricted | Duration of active account + 1 year | 7 years from account closure | ~8+ years | AML/CTF Act (Australia), GDPR |
+| Transaction records | Confidential | 2 years | 7 years from transaction date | 7 years | Tax law, PCI DSS, AML/CTF Act |
+| Audit logs | Confidential | 1 year (hot storage) | 7 years (cold storage) | 7 years | Regulatory, [Audit](L3-006) |
+| User profiles | Confidential | Duration of active account | 30 days after account closure (then anonymised or deleted) | Account lifetime + 30 days | GDPR right to erasure, Australian Privacy Act |
+| Campaign content | Internal/Public | Duration of campaign + 2 years | 5 years from campaign close | ~7 years | Business continuity, dispute resolution |
+| Donor contribution history | Confidential | Duration of active account | 7 years from transaction date | 7 years | Tax law, donor receipts |
+| Payment card tokens | Restricted | Duration of active payment method | Deleted on payment method removal | Variable | PCI DSS |
+| Session and authentication data | Internal | Duration of session | 90 days | ~90 days | Security best practice |
+| Analytics and telemetry | Internal | 1 year | 2 years (aggregated, anonymised) | 3 years | Business intelligence |
+| System logs (non-audit) | Internal | 30 days (hot) | 1 year (cold) | ~13 months | Operational needs |
+
+### 2.2 Retention Enforcement
+
+- Retention policies are enforced automatically.
+  Manual deletion processes are not acceptable as the primary retention mechanism.
+- Automated retention enforcement jobs run on a **daily** cadence to identify and process data that has exceeded its retention period.
+- Data past its retention period must be either deleted or anonymised, depending on the data type (see Section 4).
+- Retention enforcement must produce an audit record of what was deleted or anonymised, when, and by which process.
+
+> **Local demo note**: Retention enforcement jobs are not active in the local demo environment. Retention behaviour can be demonstrated manually via admin tooling.
+
+### 2.3 Legal Hold
+
+- A legal hold mechanism must exist to suspend retention-based deletion for specified data when required by legal proceedings or regulatory investigation.
+- Legal holds override automated retention enforcement.
+- Legal holds must be scoped to specific data subjects, data types, or date ranges — not applied globally.
+- Application and removal of legal holds must be logged in the audit trail.
+- Legal holds are applied and removed **manually via admin tooling** by authorised personnel. Integration with external legal case management systems is not in scope.
+
+---
+
+## 3. Data Lifecycle
+
+Data in the Mars Mission Fund platform moves through defined lifecycle stages.
+Each stage has specific handling rules, access controls, and storage requirements.
+
+### 3.1 Lifecycle Stages
+
+```text
+Creation → Active Use → Archival → Deletion/Anonymisation
+```
+
+| Stage | Description | Storage Tier | Access Pattern |
+| --- | --- | --- | --- |
+| **Creation** | Data enters the system via user input, API integration, or system generation. | Primary (hot) | Write-once, validated at system boundary per [Engineering Standard](L2-002), Section 1.4 |
+| **Active Use** | Data is actively read and updated by platform operations. | Primary (hot) | Read/write by authorised roles |
+| **Archival** | Data is no longer actively used but must be retained for regulatory or business reasons. | Archive (cold) | Read-only, access requires justification and audit logging |
+| **Deletion / Anonymisation** | Data has exceeded its retention period or a deletion request has been fulfilled. | N/A | Irreversible removal or irreversible anonymisation |
+
+### 3.2 Stage Transitions
+
+- **Creation → Active Use**: Immediate upon successful validation and persistence.
+- **Active Use → Archival**: Triggered by retention policy (data exceeds active retention period) or by business event (e.g., account closure, campaign completion).
+- **Archival → Deletion/Anonymisation**: Triggered by retention policy (data exceeds archive retention period) or by right-to-erasure request.
+
+### 3.3 Immutable Data
+
+Some data types are immutable after creation and do not transition through Active Use in the read/write sense:
+
+- Audit log entries (governed by [Audit](L3-006))
+- Transaction records (once settled)
+- KYC verification results
+
+Immutable data moves directly from Creation to a read-only Active state and then follows normal archival and deletion schedules.
+
+---
+
+## 4. Anonymisation and Pseudonymisation
+
+### 4.1 Definitions
+
+- **Anonymisation**: Irreversible removal of all identifying information such that the data subject cannot be re-identified, even by the data controller.
+  Anonymised data is no longer personal data under GDPR or the Australian Privacy Act.
+- **Pseudonymisation**: Replacement of identifying information with artificial identifiers.
+  The mapping between pseudonyms and real identities is stored separately and protected.
+  Pseudonymised data is still personal data under GDPR.
+
+### 4.2 When to Anonymise
+
+- **Right-to-erasure requests (GDPR Article 17)**: When a data subject requests deletion, data that must be retained for legal or regulatory reasons (e.g., transaction records for tax compliance) is anonymised rather than deleted.
+  Data with no retention requirement is deleted outright.
+- **Retention expiry**: When Confidential data exceeds its archive retention period and is still needed for aggregate analytics, it is anonymised before the underlying records are deleted.
+- **Analytics and reporting**: Data used for platform analytics, donor trends, and impact reporting must be anonymised or aggregated before use.
+  No analytics pipeline may process identifiable personal data.
+
+### 4.3 Anonymisation Requirements
+
+- Anonymisation must be irreversible.
+  There must be no technical mechanism to re-identify anonymised data.
+- Anonymisation must address all direct identifiers (name, email, address, phone, government IDs) and indirect identifiers that could enable re-identification in combination (date of birth + postcode + donation amount).
+- The anonymisation technique is **k-anonymity**: each released record must be indistinguishable from at least *k*-1 other records on quasi-identifier attributes. The value of *k* is determined per dataset based on re-identification risk assessment, with a minimum of *k* = 5.
+- Quasi-identifiers (e.g., date of birth, postcode, donation amount ranges) are generalised or suppressed to achieve the target *k* value.
+- The anonymisation approach must be documented and reviewed against re-identification risk before deployment.
+
+### 4.4 Pseudonymisation Requirements
+
+- Pseudonymisation is used in environments where data must be realistic but not identifiable — e.g., staging environments, QA testing, and internal analytics that require relational integrity.
+- The pseudonym-to-identity mapping must be stored separately from the pseudonymised data, encrypted at rest (AES-256), and accessible only to Restricted-level access roles.
+- Pseudonymisation must preserve referential integrity — records linked by a user ID must remain linked by the same pseudonym.
+
+### 4.5 Right-to-Erasure Workflow
+
+When a data subject exercises their right to erasure:
+
+1. Identify all data associated with the data subject across all services and storage systems.
+1. Categorise each data element as: deletable (no retention requirement), anonymisable (retention requirement exists), or exempt (legal hold in effect).
+1. Delete all deletable data.
+1. Anonymise all anonymisable data.
+1. Log the erasure action (what was deleted, what was anonymised, what was exempt and why) in the audit trail.
+1. Confirm completion to the data subject within the regulatory timeframe (GDPR: 30 days).
+
+**Backup handling**: Right-to-erasure requests are not retroactively applied to existing backups. Backups containing deleted or anonymised data are accepted as-is and will expire naturally according to the backup retention schedule (see Section 6.3). This approach is documented in the platform's GDPR compliance record as a proportionate measure, given that backup data is encrypted, access-controlled, and time-bounded.
+
+---
+
+## 5. Data Access Patterns and Controls
+
+### 5.1 Access by Classification Level
+
+| Classification | Who Can Access | Access Mechanism | Logging |
+| --- | --- | --- | --- |
+| **Public** | Any user, including unauthenticated visitors (via public APIs/pages) | Standard API/UI | Standard request logging |
+| **Internal** | Authenticated platform users with appropriate role | RBAC via data access layer | Standard structured logging |
+| **Confidential** | Users with explicit need-to-know role assignment | RBAC via data access layer, attribute-based filters | All access logged with actor, resource, and purpose |
+| **Restricted** | Users with Restricted-access role, MFA verified | RBAC + MFA challenge, via data access layer | All access logged, alerted, and periodically reviewed |
+
+### 5.2 Data Access Layer
+
+As required by [Engineering Standard](L2-002), Section 1.2, all data access goes through a data access layer.
+This layer enforces:
+
+- Parameterised queries only.
+- Classification-based access control checks before data retrieval.
+- Structured access logging (who accessed what, when, and via which operation).
+- Data masking for Confidential and Restricted fields in non-privileged contexts (e.g., showing `****1234` for card numbers).
+
+### 5.3 Cross-Service Data Access
+
+Services may only access data they own.
+If a service needs data owned by another service, it must request it via the owning service's API — not by directly querying another service's data store.
+
+This boundary is enforced at the infrastructure level (separate database credentials per service) and at the application level (service-to-service API contracts).
+
+Cross-service data access patterns must be documented in the relevant [Architecture](L3-001) service boundary definitions.
+
+### 5.4 Bulk Data Access
+
+Bulk data exports (reporting, analytics, regulatory submissions) must:
+
+- Be authorised by a role with explicit bulk-access permission.
+- Be logged as a distinct audit event including scope, row count, and classification level of exported data.
+- Apply anonymisation or pseudonymisation where the bulk use case does not require identified data.
+- Never be performed against production data stores directly — use read replicas or dedicated reporting stores.
+
+---
+
+## 6. Backup and Recovery
+
+### 6.1 Backup Requirements
+
+Backup frequency and recovery targets are defined in [Reliability](L3-003).
+This spec defines the data-specific implementation requirements.
+
+- All backups must be encrypted at rest using AES-256, per [Engineering Standard](L2-002), Section 1.1.
+- Backup encryption keys must be managed separately from the data encryption keys used for live data.
+- Backups must maintain data classification metadata — a backup of Restricted data is itself Restricted.
+- Backup storage must reside in a different failure domain (availability zone or region) from primary storage.
+
+### 6.2 Recovery Requirements
+
+- Recovery procedures must be documented, tested, and executable by on-call engineers without requiring access to documentation outside the runbook.
+- Recovery testing must occur at a defined cadence (minimum quarterly) to verify that backups are restorable and that recovered data is consistent.
+- Recovery time objectives (RTO) and recovery point objectives (RPO) are defined in [Reliability](L3-003).
+  This spec ensures the data layer can meet those targets.
+
+### 6.3 Backup Schedule
+
+Backups are taken at two cadences:
+
+- **Incremental (delta) backups**: every 15 minutes, capturing changes since the last backup.
+- **Full snapshots**: daily, capturing the complete state of each data store.
+
+> **Local demo note**: Backup infrastructure is not active in the local demo environment. The schedule above represents the production target.
+
+### 6.4 Backup Retention
+
+- Backups follow their own retention schedule, separate from the data retention schedule in Section 2.
+- Backup retention must be at least as long as the shortest regulatory retention period for the data they contain.
+- Right-to-erasure requests are **not** retroactively applied to existing backups. Backups containing deleted or anonymised data expire naturally according to backup retention periods. This is acceptable because backups are encrypted at rest, access-controlled at the Restricted level, and time-bounded (see Section 4.5 for rationale).
+
+---
+
+## 7. Migration Strategy
+
+### 7.1 Schema Migration Principles
+
+As required by [Engineering Standard](L2-002), Section 7.4:
+
+- All schema migrations must be backward-compatible.
+  The previous application version must function correctly against the new schema.
+- Migrations are versioned, idempotent, and applied automatically as part of the deployment pipeline.
+- Every migration has a corresponding rollback migration that can reverse the schema change without data loss.
+
+### 7.2 Migration Patterns
+
+| Change Type | Pattern | Notes |
+| --- | --- | --- |
+| Add column | Add with default or nullable | Previous version ignores new column |
+| Remove column | Two-phase: (1) stop writing, (2) drop in next release | Previous version can still read the column |
+| Rename column | Two-phase: (1) add new column + dual-write, (2) drop old column in next release | Maintains backward compatibility |
+| Change column type | Two-phase: (1) add new column with new type + dual-write + backfill, (2) drop old column | Never alter a column type in place |
+| Add table | Straightforward | No backward compatibility concern |
+| Remove table | Two-phase: (1) stop all access, (2) drop in next release after verification | Verify no remaining consumers |
+
+### 7.3 Data Migration
+
+Migrations that transform existing data (not just schema) must:
+
+- Be tested against a production-scale dataset in a staging environment before execution.
+- Include validation checks that verify data integrity after migration.
+- Be reversible or have a documented recovery plan.
+- Be performed during a maintenance window if they affect Restricted or Confidential data at scale.
+- Produce audit records of what was transformed.
+
+---
+
+## 8. Data Residency and Sovereignty
+
+### 8.1 Primary Data Region
+
+The primary data region is **US (United States)**. All data classifications are stored and processed in US-based infrastructure unless otherwise specified.
+
+### 8.2 Requirements
+
+- Personal data of users residing in the EU must be stored and processed in a manner compliant with GDPR data transfer requirements. Cross-border transfers from EU to US rely on Standard Contractual Clauses (SCCs) or equivalent adequacy mechanisms.
+- Personal data of Australian users must comply with the Australian Privacy Principles regarding cross-border disclosure.
+- Specific data centre locations within the US are determined by infrastructure decisions in [Architecture](L3-001).
+
+### 8.3 Multi-Region and Edge Considerations
+
+- Multi-region replication is not currently in use. If introduced, data classification constraints must be maintained — Restricted and Confidential data replication requires explicit approval and documentation.
+- CDN and edge caching is permitted only for Public-classified content. Cache TTLs and invalidation policies are defined in [Architecture](L3-001).
+
+> **Local demo note**: Data residency is not enforced in the local demo environment. All data resides on the local machine.
+
+---
+
+## 9. Interface Contracts
+
+### 9.1 L3-002 (Security) Interface
+
+| This Spec Provides | Security Spec Provides |
+| --- | --- |
+| Data classification scheme (Section 1) defining what "sensitive" means for encryption and access control purposes | RBAC model defining roles and permissions that map to classification-level access |
+| Anonymisation and pseudonymisation rules (Section 4) for privacy compliance | Compliance control matrix (GDPR, Australian Privacy Act, PCI DSS) informing retention and handling rules |
+| Backup encryption requirements (Section 6) | Encryption key management architecture and key rotation policies |
+
+### 9.2 L3-001 (Architecture) Interface
+
+| This Spec Provides | Architecture Spec Provides |
+| --- | --- |
+| Data access layer requirements (Section 5.2) — what the layer must enforce | Data access layer implementation — technology choice, service placement, connection management |
+| Cross-service data boundary rules (Section 5.3) | Service boundary definitions and inter-service communication patterns |
+| Data residency requirements (Section 8) | Infrastructure topology, region selection, replication strategy |
+
+### 9.3 L3-003 (Reliability) Interface
+
+| This Spec Provides | Reliability Spec Provides |
+| --- | --- |
+| Backup implementation requirements (Section 6) — encryption, classification, recovery testing | Backup frequency, RTO, RPO targets |
+| Data lifecycle stages affecting availability (Section 3) — archival reduces hot-storage load | Availability targets and failover strategies that the data layer must support |
+
+### 9.4 L4-004 (Payments) Interface
+
+| This Spec Provides | Payments Spec Provides |
+| --- | --- |
+| Classification of payment data (Restricted) and retention rules for transaction records (7 years) | Specific payment data types, tokenisation approach, PCI DSS scope boundaries |
+| Anonymisation rules for financial data subject to right-to-erasure | Definition of which financial records are legally exempt from erasure |
+
+### 9.5 L4-005 (KYC) Interface
+
+| This Spec Provides | KYC Spec Provides |
+| --- | --- |
+| Classification of KYC documents (Restricted) and retention rules (7+ years) | Specific document types, verification workflows, jurisdictional requirements |
+| Right-to-erasure handling for identity documents | Definition of which identity records are legally required to be retained post-erasure request |
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| --- | --- | --- | --- |
+| March 2026 | 0.1 | — | Initial stub. Data classification scheme (four levels with MMF examples), retention policies by data type, data lifecycle stages, anonymisation and pseudonymisation rules, right-to-erasure workflow, data access patterns and controls, backup and recovery requirements, schema and data migration strategy, data residency placeholders, interface contracts with L3-001/L3-002/L3-003/L4-004/L4-005. |
+| March 2026 | 0.2 | — | Resolved all open questions (OQ-1 through OQ-6). Set primary data region to US. Adopted k-anonymity for anonymisation. Set daily retention enforcement cadence. Confirmed manual legal hold process. Defined backup schedule (15-min deltas, daily full). Accepted backup-expiry approach for right-to-erasure propagation. Added local demo notes throughout. |

--- a/specs/tech/frontend.md
+++ b/specs/tech/frontend.md
@@ -1,0 +1,520 @@
+# Frontend Standards
+
+> **Spec ID**: L3-005
+> **Version**: 0.3
+> **Status**: Approved
+> **Rate of Change**: Sprint-level / tech decisions
+> **Depends On**: L2-001 (Brand Application Standard), L2-002 (Engineering Standard), L3-001 (Architecture)
+> **Depended On By**: L4-001 (domain/account.md), L4-002 (domain/campaign.md), L4-003 (domain/donor.md)
+
+---
+
+## Purpose
+
+> **Local demo scope**: React component architecture, semantic token consumption, accessibility standards (WCAG 2.1 AA), and the testing strategy are **real** — they drive the local demo's frontend implementation. Lighthouse CI enforcement, bundle size budgets, visual regression testing, and SSR/SSG decisions are theatre until the application is deployed beyond local.
+
+This spec governs the frontend architecture, component library standards, performance requirements, accessibility implementation, responsive design strategy, and browser support for the Mars Mission Fund platform.
+
+It **implements** the brand token system defined in the [Brand Application Standard](L2-001) — specifically the Tier 2 semantic tokens that are the only tokens components may consume.
+
+It **inherits** engineering constraints from the [Engineering Standard](L2-002) — quality gates, testing requirements, security invariants, and observability baseline.
+
+It **does not cover**:
+
+- Brand identity, voice, or token definitions — those live in [Brand Application Standard](L2-001).
+- Backend API design, service boundaries, or infrastructure — those live in [Architecture](L3-001).
+- Domain-specific UI workflows (account registration, campaign pages, donor dashboards) — those live in the L4 domain specs that depend on this document.
+
+---
+
+## Inherited Constraints
+
+### From L2-002 (Engineering Standard)
+
+| Section | Constraint | Frontend Implication |
+| ------- | ---------- | -------------------- |
+| 1.4 — Input Validation | All external input validated at system boundary | All form inputs validated client-side before submission; server-side validation is authoritative |
+| 1.4 — CSP | Content Security Policy headers mandatory | No inline scripts, no `eval()`, no `unsafe-inline` in style or script directives |
+| 1.6 — Dependency Security | Dependencies scanned on every build; abandoned packages prohibited | Frontend dependency tree audited in CI; no packages without active maintenance |
+| 4.1 — Code Quality | Automated linting and formatting; strict type safety | Linter and formatter enforced in CI; strict TypeScript mode (`strict: true`) |
+| 4.2 — Test Coverage | 80% coverage for UI components | Unit + snapshot tests on all shared components; coverage gate in CI |
+| 4.4 — Pre-Merge Checklist | All gates pass before merge | Frontend-specific CI checks (build, lint, type-check, test, bundle size, accessibility audit) |
+| 5.3 — Error Response Contract | Consistent error format with human-readable message | Frontend error handling consumes machine-readable error codes and displays user-facing messages following [Brand Application Standard](L2-001) Section 4 voice patterns |
+| 6.2 — Correlation IDs | Every request carries a correlation ID | Frontend HTTP client attaches correlation ID to all API requests; ID surfaced in error reporting |
+
+### From L2-001 (Brand Application Standard)
+
+| Section | Constraint | Frontend Implication |
+| ------- | ---------- | -------------------- |
+| Token Architecture | Components consume Tier 2 semantic tokens only | Direct reference to Tier 1 identity tokens in component code is a build-time lint violation |
+| Section 3 — Component Specs | Mandatory component-to-token mappings | Component library implements exact token mappings from L2-001 Section 3 |
+| Section 5 — Accessibility | WCAG 2.1 AA minimum; focus states; screen reader requirements | Accessibility audit enforced in CI; all components meet Section 5 requirements |
+| Section 7 — Dark Mode | Dark-first; no light mode for core application | Single dark theme; light-theme overrides only for exception contexts (email, PDF, embedded widgets) |
+| Section 8 — Brand Misuse | Violations flagged in code review | Automated lint rules for detectable violations (Tier 1 token usage, custom colours, suppressed focus indicators) |
+
+---
+
+## 1. Frontend Architecture
+
+### 1.1 Framework Selection
+
+The frontend framework is **React 19.x**, selected per [Tech Stack](L3-008).
+React 19 meets all selection criteria: first-class TypeScript support, mature component model, SSR/SSG capability, large ecosystem, and strong accessibility tooling.
+
+The build tool is **Vite** (per [Tech Stack](L3-008)), providing fast development server, HMR, and optimised production builds.
+
+### 1.1.1 Rendering Strategy
+
+The application is a **single-page application (SPA)** with **selective static pre-rendering** for SEO-relevant pages.
+
+| Page type | Rendering | Rationale |
+| --------- | --------- | --------- |
+| Marketing / landing pages | Static pre-rendering at build time (via `vite-plugin-ssr` or equivalent) | SEO-critical; content changes infrequently; can be served directly from CDN |
+| Public campaign pages | Static pre-rendering with revalidation (rebuild on campaign publish/update) | SEO-important; content is user-generated but changes on known events |
+| Authenticated pages (dashboard, account, contribution flows) | Client-side SPA rendering | Not SEO-relevant; require authentication; benefit from SPA interactivity |
+
+Full server-side rendering (SSR) is not required at this stage. The SPA + selective pre-rendering approach avoids SSR infrastructure complexity while covering SEO needs. If SSR becomes necessary (e.g., for dynamic meta tags on campaign pages at scale), the architecture can adopt a framework like React Router's SSR mode or a lightweight Node SSR layer without restructuring the component library.
+
+The following architectural constraints apply.
+
+### 1.2 Component-Based Architecture
+
+The UI is built from a hierarchy of composable components.
+
+| Component Tier | Description | Ownership |
+| -------------- | ----------- | --------- |
+| **Design system primitives** | Button, Input, Card, Badge, ProgressBar, StatCard — implementing [Brand Application Standard](L2-001) Section 3 exactly | Shared library; changes require design review |
+| **Composite components** | Form groups, navigation, campaign cards, stat dashboards — assembled from primitives | Feature teams; must only use primitives from the design system |
+| **Page components** | Full page layouts — assembled from composites; manage data fetching and state | Feature teams; defined by L4 domain specs |
+
+**Rule**: No component may define its own colours, font sizes, spacing, or animation timings.
+All visual properties are consumed from semantic tokens.
+Hardcoded visual values in component code are a spec violation.
+
+### 1.3 State Management
+
+State management uses a **layered approach** that avoids heavy frameworks in favour of React's built-in primitives and a dedicated server-state library.
+
+| Layer | Tool | Scope |
+| ----- | ---- | ----- |
+| **Server state** | TanStack Query (React Query) v5 | All API data: campaigns, accounts, contributions, funding progress. Handles caching, revalidation, optimistic updates, and background refetching. |
+| **Local UI state** | React `useState` / `useReducer` | Form state, modal visibility, UI toggles — ephemeral state that does not survive navigation. |
+| **Shared client state** | React Context + `useReducer` | Authentication state, user preferences, correlation ID — small amount of cross-cutting state shared across the component tree. |
+
+**Why TanStack Query**: It is the lightest-touch solution that satisfies the server-state requirements (caching with revalidation, optimistic mutations with rollback, background polling for real-time progress) without introducing a global state framework like Redux or Zustand. All server data flows through TanStack Query; no component fetches or caches API data outside this layer.
+
+**Why not a global store**: The application's complexity is overwhelmingly server-state-driven (campaigns, contributions, account data). A global client store adds indirection without benefit when TanStack Query already manages the cache, loading states, and error states for server data.
+
+The following constraints apply regardless of implementation detail:
+
+- Financial data (contribution amounts, funding totals, escrow status) must never be cached in client-side state beyond a single session without revalidation from the server. TanStack Query's `staleTime` for financial data must be zero (always revalidate on mount).
+- Authentication state must be managed consistently across all routes and API calls via a dedicated `AuthContext` provider at the application root.
+- State mutations that represent financial actions must use TanStack Query's mutation API with `onMutate` / `onError` rollback — the UI may show optimistic state but must revert on server rejection.
+
+### 1.4 Routing
+
+- All routes are defined declaratively.
+- Route-level code splitting is mandatory — no single route loads the entire application bundle.
+- Protected routes enforce authentication state before rendering; unauthenticated users are redirected to login.
+- Route transitions use `--motion-page` semantic token for animation timing.
+
+### 1.5 API Communication
+
+- All API communication goes through a centralised HTTP client that enforces:
+  - Correlation ID attachment (per [Engineering Standard](L2-002) Section 6.2).
+  - Authentication token injection.
+  - Consistent error handling and transformation into user-facing messages.
+  - Request/response logging (no sensitive data — per [Engineering Standard](L2-002) Section 6.1).
+- API response types are generated from or validated against the API's machine-readable documentation (per [Engineering Standard](L2-002) Section 5.5).
+- No component may call an API endpoint directly — all calls go through the centralised client.
+
+---
+
+## 2. Component Library Standards
+
+### 2.1 Token Consumption
+
+Components consume **only** Tier 2 semantic tokens from the [Brand Application Standard](L2-001).
+
+```text
+Allowed:     background: var(--color-action-primary);
+Prohibited:  background: var(--launchfire);
+Prohibited:  background: #FF5C1A;
+```
+
+A build-time lint rule must enforce this constraint.
+The rule must flag:
+
+- Direct reference to any Tier 1 identity token name in component stylesheets.
+- Hardcoded colour values (hex, rgb, rgba, hsl) in component stylesheets.
+- Hardcoded font-family, font-size, or animation-duration values in component stylesheets.
+
+### 2.2 Component Documentation
+
+Every design system primitive must include:
+
+- A TypeScript interface defining all props.
+- Usage examples for each variant.
+- Accessibility notes (ARIA attributes, keyboard behaviour, screen reader expectations).
+- A visual regression snapshot.
+
+### 2.3 Component API Design Principles
+
+- Props use semantic names, not visual ones (`variant="primary"` not `color="orange"`).
+- Boolean props default to `false`.
+- Components accept a `className` or equivalent escape hatch for layout positioning only — never for overriding visual tokens.
+- All interactive components support `disabled`, focus management, and keyboard navigation.
+
+---
+
+## 3. Performance Budgets
+
+### 3.1 Loading Performance
+
+| Metric | Budget | Measurement |
+| ------ | ------ | ----------- |
+| First Contentful Paint (FCP) | < 1.5s | Lighthouse, on 4G throttled connection |
+| Largest Contentful Paint (LCP) | < 2.5s | Lighthouse, on 4G throttled connection |
+| Time to Interactive (TTI) | < 3.5s | Lighthouse, on 4G throttled connection |
+| Cumulative Layout Shift (CLS) | < 0.1 | Lighthouse |
+| First Input Delay (FID) | < 100ms | Real User Monitoring (RUM) |
+
+### 3.2 Bundle Size
+
+| Bundle | Maximum Size (gzip compressed) |
+| ------ | ------------------------------ |
+| Initial JS bundle (critical path) | 150 KB |
+| Per-route chunk (lazy loaded) | 50 KB |
+| Total CSS | 30 KB |
+| Design system primitives (JS + CSS) | 40 KB |
+
+These budgets assume React 19 + TanStack Query + router as the core dependency set (~90 KB compressed baseline). The remaining budget is for application code and design system.
+
+The principle is: every byte must justify its presence.
+Bundle analysis runs in CI via `vite-plugin-bundle-analyzer` and fails the build if budgets are exceeded.
+
+### 3.3 Runtime Performance
+
+| Metric | Target |
+| ------ | ------ |
+| Animation frame rate | 60fps minimum; no dropped frames on mid-range devices |
+| Interaction response | < 100ms for user-initiated actions (button clicks, form interactions) |
+| List rendering | Virtualised rendering for lists exceeding 50 items |
+| Image decoding | Off-main-thread; no layout jank during image load |
+
+---
+
+## 4. Accessibility Standards
+
+This section implements the requirements from [Brand Application Standard](L2-001) Section 5 and establishes additional frontend-specific accessibility standards.
+
+### 4.1 Compliance Target
+
+**WCAG 2.1 Level AA** is the minimum compliance target for all user-facing surfaces.
+
+Level AAA conformance is targeted where feasible, particularly for:
+
+- Colour contrast on primary text (the dark-first palette naturally achieves AAA — see [Brand Application Standard](L2-001) Section 5.1).
+- Keyboard navigation (all functionality available via keyboard).
+
+### 4.2 Automated Accessibility Testing
+
+- An accessibility audit tool (e.g., axe-core or equivalent) runs as part of CI on every PR.
+- Violations at the "critical" or "serious" level fail the build.
+- Accessibility tests are included in the component test suite for every design system primitive.
+
+### 4.3 Keyboard Navigation
+
+- All interactive elements are reachable via Tab key in a logical order.
+- Focus order matches the visual order of elements.
+- Modal dialogs trap focus within the dialog until dismissed.
+- Focus is restored to the triggering element when a dialog closes.
+- Skip-to-content link is provided on every page.
+- Custom interactive components (dropdowns, date pickers, tabs) implement the appropriate WAI-ARIA authoring practice keyboard pattern.
+
+### 4.4 Screen Reader Support
+
+All requirements from [Brand Application Standard](L2-001) Section 5.4 apply.
+Additionally:
+
+- Dynamic content updates (e.g., funding progress changes, real-time notifications) are announced via ARIA live regions with appropriate politeness levels.
+- Page title updates on route changes.
+- Form validation errors are associated with their inputs via `aria-describedby` and announced on submission.
+- Loading states are communicated via `aria-busy` and descriptive status text.
+
+### 4.5 Motion Accessibility
+
+All animations implement `prefers-reduced-motion` as defined in [Brand Application Standard](L2-001) Section 5.2.
+
+Implementation:
+
+- A CSS media query at the root level sets all motion semantic tokens to their reduced-motion alternatives.
+- JavaScript-driven animations check the media query and adjust accordingly.
+- No animation is essential to understanding content — all animated content is accessible without motion.
+
+---
+
+## 5. Responsive Design
+
+### 5.1 Strategy
+
+The responsive strategy is **mobile-first**.
+
+CSS is authored for the smallest viewport first; larger viewports are handled via `min-width` media queries. This ensures mobile is the baseline experience rather than a degraded afterthought, and naturally produces lighter CSS (small-screen styles are unconditional; large-screen enhancements are additive).
+
+Components must be designed and reviewed at the smallest breakpoint first before scaling up.
+
+### 5.2 Breakpoints
+
+The breakpoint system uses four named breakpoints defined as CSS custom properties and as constants in the application's theme module.
+
+| Token | Value | Intended context |
+| ----- | ----- | ---------------- |
+| `--breakpoint-sm` | `640px` | Large phones in landscape; small tablets |
+| `--breakpoint-md` | `768px` | Tablets in portrait |
+| `--breakpoint-lg` | `1024px` | Tablets in landscape; small desktops |
+| `--breakpoint-xl` | `1280px` | Standard desktops and above |
+
+Media queries use `min-width` exclusively (mobile-first). Example:
+
+```css
+/* Base: single column (mobile) */
+.card-grid { grid-template-columns: 1fr; }
+
+/* sm and up: two columns */
+@media (min-width: 640px) { .card-grid { grid-template-columns: repeat(2, 1fr); } }
+
+/* lg and up: three columns */
+@media (min-width: 1024px) { .card-grid { grid-template-columns: repeat(3, 1fr); } }
+```
+
+No component may use arbitrary breakpoint values — all responsive behaviour must use one of the four named breakpoints above.
+
+Regardless of specific values, the following constraints apply:
+
+| Context | Requirement |
+| ------- | ----------- |
+| Campaign browsing | Full functionality at all breakpoints; card grid adapts from single-column to multi-column |
+| Financial flows (contribution, KYC) | Full functionality at all breakpoints; forms must be usable on mobile without horizontal scrolling |
+| Data tables (transaction history, admin views) | Responsive pattern required — horizontal scroll, card conversion, or column prioritisation |
+| Navigation | Collapses to mobile-appropriate pattern (hamburger, bottom nav, or equivalent) below tablet breakpoint |
+
+### 5.3 Touch Targets
+
+All interactive elements meet minimum touch target size of 44x44 CSS pixels on touch devices (WCAG 2.1 SC 2.5.5).
+
+---
+
+## 6. Animation & Motion
+
+### 6.1 Token Usage
+
+All animations use semantic motion tokens from [Brand Application Standard](L2-001) Section 2.9.
+No custom timing values, durations, or easing functions in component code.
+
+### 6.2 Performance Constraints
+
+| Constraint | Requirement |
+| ---------- | ----------- |
+| Frame rate | 60fps target; animations that cannot maintain 60fps must be simplified or removed |
+| Animated properties | Prefer `transform` and `opacity` only (compositor-layer animations); avoid animating `width`, `height`, `top`, `left`, or layout-triggering properties |
+| Will-change | Apply `will-change` only when an animation is imminent; remove after completion; never apply to more than a handful of elements simultaneously |
+| Main thread | No long-running JavaScript animations on the main thread; use CSS animations, Web Animations API, or requestAnimationFrame |
+
+### 6.3 Reduced Motion
+
+When `prefers-reduced-motion: reduce` is active:
+
+- All semantic motion tokens resolve to their reduced-motion alternatives as defined in [Brand Application Standard](L2-001) Section 5.2.
+- Ambient and decorative animations (`--motion-ambient`) are fully disabled (static position).
+- Essential transitions (page navigation, modal open/close) use instant or minimal fade.
+- Progress bar fills render instantly.
+
+---
+
+## 7. Browser Support Matrix
+
+The browser support policy is **latest 2 major versions** for all evergreen browsers. Specific version numbers are not pinned — the policy moves forward automatically as browsers release. If post-launch analytics reveal a significant user segment on older versions, the matrix can be tightened.
+
+### 7.1 Minimum Support Expectations
+
+| Browser | Support Level |
+| ------- | ------------- |
+| Chrome (latest 2 major versions) | Full support |
+| Firefox (latest 2 major versions) | Full support |
+| Safari (latest 2 major versions) | Full support |
+| Edge (latest 2 major versions) | Full support |
+| Mobile Safari (iOS, latest 2 major versions) | Full support |
+| Chrome for Android (latest 2 major versions) | Full support |
+| Internet Explorer | Not supported |
+
+### 7.2 Progressive Enhancement
+
+- The application requires JavaScript. When JavaScript is unavailable or disabled, the application displays a clear, styled `<noscript>` message explaining the requirement and providing guidance (graceful degradation).
+- The `<noscript>` fallback must be visually consistent with the brand (using the dark theme background and brand typography via system font fallbacks).
+- Visual enhancements (animations, gradient effects, advanced layout) may leverage modern CSS features with appropriate fallbacks.
+- Feature detection (not browser detection) is used for all capability checks.
+
+---
+
+## 8. Dark Mode Implementation
+
+### 8.1 Position
+
+Mars Mission Fund is a **dark-first product** as established in [Brand Application Standard](L2-001) Section 7.
+The core application has a single dark theme.
+There is no user-togglable light mode for the main application.
+
+### 8.2 Technical Implementation
+
+- All colour values are consumed via CSS custom properties (semantic tokens).
+- The dark theme is the default — no theme toggle or system preference detection is needed for the core application.
+- Exception contexts (email templates, PDF exports, embedded widgets) define theme-specific token override maps as described in [Brand Application Standard](L2-001) Section 7.2.
+- Exception theme overrides are scoped via a CSS class (e.g., `.theme-light`) applied to the root element of the exception context — not via media queries or system preferences.
+
+---
+
+## 9. Asset Optimisation
+
+### 9.1 Font Loading
+
+The brand typography defined in [Brand Application Standard](L2-001) Section 1.3 requires loading three web fonts:
+
+| Font | Identity Token | Usage |
+| ---- | -------------- | ----- |
+| Bebas Neue | `--font-display` | Display headings, hero text, stat values |
+| DM Sans | `--font-body` | Body text, buttons, card titles |
+| Space Mono | `--font-data` | Labels, data values, mission codes |
+
+Font loading strategy:
+
+- Fonts are self-hosted (no third-party font CDN dependency).
+- `font-display: swap` for body font (DM Sans) to prevent invisible text.
+- `font-display: optional` for display font (Bebas Neue) on slow connections — fallback is acceptable for display headings.
+- Data font (Space Mono) loaded with `font-display: swap`.
+- Font files served in WOFF2 format with appropriate subset (Latin + extended Latin).
+- Font preload hints (`<link rel="preload">`) for DM Sans (critical text rendering).
+
+### 9.2 Image Optimisation
+
+| Requirement | Implementation |
+| ----------- | -------------- |
+| Format | Modern formats (WebP, AVIF) with fallback to JPEG/PNG |
+| Responsive images | `srcset` and `sizes` attributes for all content images |
+| Lazy loading | Images below the fold use `loading="lazy"` |
+| Aspect ratio | Explicit `width` and `height` attributes on all `<img>` elements to prevent CLS |
+| CDN | Images served via CDN with appropriate cache headers |
+| Uploads | User-uploaded images (campaign photos, KYC documents) served from a separate domain per [Engineering Standard](L2-002) Section 1.4 |
+
+### 9.3 Icon System
+
+Icons are implemented as **inline SVG React components**.
+
+Each icon is a React component that renders an `<svg>` element directly into the DOM. This approach is selected over SVG sprites and icon fonts for the following reasons:
+
+- **Tree-shakeable**: Only icons actually imported are included in the bundle.
+- **Accessible by default**: Each icon component accepts `aria-label` and renders `role="img"`; decorative icons render `aria-hidden="true"`.
+- **Styleable via tokens**: SVG `fill` and `stroke` inherit from CSS `currentColor`, which is set via semantic colour tokens.
+- **No runtime fetch**: No sprite sheet HTTP request; icons are part of the JS bundle and render synchronously.
+
+Icon components follow a consistent API:
+
+```tsx
+interface IconProps {
+  size?: 'sm' | 'md' | 'lg';       // maps to semantic spacing tokens
+  label?: string;                   // sets aria-label; omit for decorative icons
+  className?: string;               // layout positioning only
+}
+```
+
+The project uses a curated subset of an open-source icon library (e.g., Lucide, Heroicons, or Phosphor) wrapped in project-specific components to maintain a single icon API. Direct use of the upstream library in component code is prohibited — all icons are re-exported through the project's icon module.
+
+---
+
+## 10. Frontend Testing Strategy
+
+Implements [Engineering Standard](L2-002) Section 4.2: 80% coverage for UI components.
+
+### 10.1 Test Layers
+
+| Layer | Scope | Tool |
+| ----- | ----- | ---- |
+| Unit tests | Individual component rendering, prop variations, event handling | Vitest + React Testing Library |
+| Snapshot tests | Visual regression detection for design system primitives | Vitest inline snapshots |
+| Integration tests | Component composition, form flows, API interaction (mocked) | Vitest + React Testing Library + MSW (Mock Service Worker) |
+| End-to-end tests | Critical user flows: contribution, campaign browsing, account management | Playwright |
+| Accessibility tests | Automated WCAG audit on every component | axe-core (via `vitest-axe` for unit tests; `@axe-core/playwright` for E2E) |
+| Visual regression tests | Screenshot comparison for design system components | Playwright screenshot assertions |
+| API integration tests | Backend API endpoint testing (mocked or local server) | Supertest |
+
+**Tool rationale**:
+
+- **Vitest**: Native Vite integration, fast HMR-aware test execution, compatible with Jest API. Preferred over Jest for Vite-based projects.
+- **React Testing Library**: Tests components from the user's perspective (queries by role, label, text) rather than implementation details. Reinforces accessibility-first component design.
+- **MSW (Mock Service Worker)**: Intercepts HTTP requests at the network level, allowing integration tests to exercise the real API client (including correlation ID attachment, error handling) without hitting a server.
+- **Playwright**: Cross-browser E2E testing with first-class support for accessibility testing via axe-core integration. **Playwright MCP** (via `@anthropic-ai/mcp-playwright` or `@anthropic-ai/playwright-mcp`) is used during development for efficient LLM/AI agent integration — enabling AI-assisted test authoring, debugging, and visual inspection of test state.
+- **Supertest**: Lightweight HTTP assertion library for testing Express API endpoints in isolation.
+
+### 10.2 Coverage Requirements
+
+| Component Type | Minimum Coverage | Notes |
+| -------------- | ---------------- | ----- |
+| Design system primitives | 90% | Higher bar — these are shared foundations |
+| Composite components | 80% | Per [Engineering Standard](L2-002) Section 4.2 |
+| Page components | 70% | Focus on integration and data flow; visual coverage via E2E |
+| Utility functions | 90% | Pure functions; easy to test exhaustively |
+
+### 10.3 CI Integration
+
+- All test layers run on every PR.
+- Test failures block merge (per [Engineering Standard](L2-002) Section 4.4).
+- Coverage reports are generated and compared against thresholds.
+- Bundle size analysis runs on every PR with comparison against budgets.
+- Lighthouse CI runs on key pages with performance budget enforcement.
+- Accessibility audit runs on every PR.
+
+---
+
+## Interface Contracts
+
+### With L2-001 (Brand Application Standard)
+
+This spec **consumes** the Tier 2 semantic token system defined in [Brand Application Standard](L2-001) Section 2.
+The component library implements the component specifications defined in [Brand Application Standard](L2-001) Section 3.
+Voice-in-product patterns from [Brand Application Standard](L2-001) Section 4 govern all user-facing text rendered by frontend components.
+
+**Interface**: Semantic token CSS custom properties.
+Changes to the semantic token set in L2-001 require corresponding updates to the component library and this spec.
+
+### With L3-001 (Architecture)
+
+This spec **consumes** the API contracts, service boundaries, and deployment topology defined in [Architecture](L3-001).
+The frontend is deployed as defined in L3-001; the frontend build pipeline integrates with the CI/CD architecture defined there.
+
+**Interface**: API endpoints, authentication mechanism, deployment pipeline.
+Changes to API contracts require corresponding updates to the frontend API client and generated types.
+
+### With L4-001 (Account), L4-002 (Campaign), L4-003 (Donor)
+
+These domain specs **consume** the component library, responsive design system, accessibility standards, and performance budgets defined in this spec.
+Domain specs define the specific pages, workflows, and data requirements; this spec defines how those are built.
+
+**Interface**: Component library API, design tokens, layout system.
+Domain specs may not introduce visual properties that bypass this spec's token and component constraints.
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| ---- | ------- | ------ | ------- |
+| March 2026 | 0.1 | — | Initial stub. Frontend architecture constraints, component library standards, performance budgets, accessibility implementation, responsive design, animation constraints, browser support, dark mode implementation, asset optimisation, and testing strategy. Framework selection and specific breakpoints deferred as open decisions. |
+| March 2026 | 0.2 | — | Resolved OQ-1: React 19.x selected as frontend framework per L3-008. |
+| March 2026 | 0.3 | — | Resolved OQ-2 through OQ-9: Mobile-first responsive strategy with breakpoints at 640/768/1024/1280px. Bundle size budgets established. TanStack Query + React built-in state for state management. Inline SVG React components for icons. Vitest + React Testing Library + Playwright + MSW + Supertest for testing (with Playwright MCP for AI agent integration). SPA with selective static pre-rendering for SEO pages. Graceful degradation for no-JS with branded noscript fallback. |
+
+---
+
+*This spec governs how the Mars Mission Fund frontend is built.
+For brand identity and token definitions, see the [Brand Application Standard](L2-001).
+For engineering constraints inherited by this spec, see the [Engineering Standard](L2-002).
+For system architecture and API contracts, see [Architecture](L3-001).*

--- a/specs/tech/markdown.md
+++ b/specs/tech/markdown.md
@@ -1,0 +1,296 @@
+# Markdown Standard
+
+> **Spec ID**: L3-007
+> **Version**: 1.0
+> **Status**: Approved
+> **Rate of Change**: Sprint level / technology decisions
+> **Depends On**: L2-002 (standards/engineering.md)
+> **Depended On By**: All specs in this repository
+
+---
+
+## Purpose
+
+This document defines how Markdown files are authored, formatted, and validated across the Mars Mission Fund codebase.
+Consistent Markdown matters because specifications, documentation, and READMEs are engineering artefacts — they receive the same quality standards as code (L2-002, Section 4).
+
+> **Local demo scope:** Fully enforced.
+> The markdownlint configuration and one-sentence-per-line rule apply to the local demo — all specs and docs in this repo are validated against this standard.
+
+---
+
+## 1. Line Structure
+
+### 1.1 One Sentence Per Line
+
+Every sentence starts on its own line.
+Every line contains at most one sentence.
+
+This is the single most important formatting rule in this spec.
+
+**Why**:
+
+- Git diffs become sentence-level, not paragraph-level.
+  Reviewers see exactly which sentence changed.
+- Reordering, deleting, or editing a sentence never produces a noisy diff that obscures the actual change.
+- Merge conflicts are isolated to the sentence that was edited, not the entire paragraph.
+
+**Correct**:
+
+```markdown
+Mars Mission Fund uses escrow-based funding.
+Funds are released only when milestones are verified.
+This protects both donors and campaign teams.
+```
+
+**Incorrect**:
+
+```markdown
+Mars Mission Fund uses escrow-based funding. Funds are released only when milestones are verified. This protects both donors and campaign teams.
+```
+
+### 1.2 Line Length
+
+Line length is not enforced by a hard character limit (markdownlint MD013 is disabled).
+The one-sentence-per-line rule naturally keeps lines at a reasonable length.
+
+If a single sentence exceeds ~120 characters, consider whether the sentence itself is too long and should be split for readability — not for formatting.
+
+### 1.3 Blank Lines
+
+Use a single blank line to separate block-level elements (headings, paragraphs, lists, code blocks, tables).
+Never use multiple consecutive blank lines (MD012).
+
+---
+
+## 2. Headings
+
+### 2.1 Style
+
+Use ATX-style headings (`#`, `##`, `###`).
+Do not use setext-style (underline) headings (MD003).
+
+### 2.2 Hierarchy
+
+Heading levels increment by one.
+Do not skip levels — e.g., jumping from `##` to `####` (MD001).
+
+Every document must start with a single top-level heading (`#`) as the first line (MD041).
+Only one `#` heading per document (MD025).
+
+### 2.3 Blank Lines Around Headings
+
+Every heading must have a blank line before and after it (MD022).
+
+### 2.4 Trailing Punctuation
+
+Headings must not end with punctuation (MD026).
+Exception: question marks are permitted in FAQ-style headings.
+
+---
+
+## 3. Lists
+
+### 3.1 Unordered Lists
+
+Use `-` as the list marker.
+Do not use `*` or `+` (MD004, configured for `dash`).
+
+### 3.2 Ordered Lists
+
+Use `1.` for all items in ordered lists (MD029, configured for `one`).
+Markdown renderers will number them correctly.
+This avoids noisy diffs when items are reordered.
+
+### 3.3 Indentation
+
+Indent nested list items by 2 spaces (MD007).
+
+### 3.4 Blank Lines Around Lists
+
+Lists must be surrounded by blank lines (MD032).
+
+---
+
+## 4. Code
+
+### 4.1 Code Blocks
+
+Use fenced code blocks with backticks (`` ``` ``), not indented code blocks (MD046).
+Do not use tildes (`~~~`) for fences (MD048).
+
+Every fenced code block must specify a language identifier (MD040).
+
+### 4.2 Code Spans
+
+Inline code uses single backticks.
+No spaces inside code span backticks (MD038).
+
+---
+
+## 5. Links and Images
+
+### 5.1 No Bare URLs
+
+URLs must be wrapped in angle brackets or used as part of a Markdown link (MD034).
+
+### 5.2 Image Alt Text
+
+Every image must have meaningful alt text (MD045).
+
+### 5.3 Link Text
+
+Link text must be descriptive.
+Do not use "click here" or "link" as link text (MD059).
+This aligns with the brand voice requirement in L2-001 (Section 4.3, Forbidden Language Patterns).
+
+---
+
+## 6. Emphasis
+
+Use `*` for italic and `**` for bold.
+Do not use `_` or `__` (MD049, MD050).
+No spaces inside emphasis markers (MD037).
+
+---
+
+## 7. Tables
+
+Tables must be surrounded by blank lines (MD058).
+Pipe characters must have consistent spacing (MD055).
+Every table must have the correct number of columns in every row (MD056).
+Separator rows must use padded style with spaces around dashes, matching the header row spacing (MD060).
+
+**Correct**:
+
+```markdown
+| Name | Value |
+| ---- | ----- |
+| Foo  | Bar   |
+```
+
+**Incorrect**:
+
+```markdown
+| Name | Value |
+|------|-------|
+| Foo  | Bar   |
+```
+
+---
+
+## 8. Horizontal Rules
+
+Use `---` for horizontal rules.
+Maintain a consistent style throughout the document (MD035).
+
+---
+
+## 9. Inline HTML
+
+Inline HTML is not permitted in specification documents (MD033).
+Markdown must be sufficient for all spec content.
+
+---
+
+## 10. Whitespace
+
+No trailing spaces at end of lines (MD009).
+No hard tabs — use spaces only (MD010).
+Files must end with a single newline character (MD047).
+
+---
+
+## 11. Linter
+
+This project uses [markdownlint](https://github.com/DavidAnson/markdownlint) to enforce these rules automatically.
+
+### 11.1 VS Code Extension
+
+Install the VS Code extension for real-time linting:
+
+```bash
+code --install-extension DavidAnson.vscode-markdownlint
+```
+
+Or search for "markdownlint" in the VS Code Extensions panel (`Cmd+Shift+X`).
+
+The extension highlights violations inline as you type and provides quick-fix actions.
+
+### 11.2 CLI
+
+For CI and pre-commit validation, use [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2):
+
+```bash
+npm install --save-dev markdownlint-cli2
+```
+
+Run against the project:
+
+```bash
+npx markdownlint-cli2 "**/*.md"
+```
+
+### 11.3 Configuration
+
+The project-level configuration lives in `.markdownlint.jsonc` at the repository root.
+This file must be kept in sync with the rules defined in this spec.
+
+The configuration matching this spec:
+
+```jsonc
+{
+  // Line length — disabled; one-sentence-per-line governs structure
+  "MD013": false,
+
+  // Unordered list marker: dash only
+  "MD004": { "style": "dash" },
+
+  // Ordered list prefix: always 1.
+  "MD029": { "style": "one" },
+
+  // List indentation: 2 spaces
+  "MD007": { "indent": 2 },
+
+  // Heading style: ATX only
+  "MD003": { "style": "atx" },
+
+  // Code block style: fenced only
+  "MD046": { "style": "fenced" },
+
+  // Code fence style: backtick only
+  "MD048": { "style": "backtick" },
+
+  // Emphasis style: asterisk only
+  "MD049": { "style": "asterisk" },
+
+  // Strong style: asterisk only
+  "MD050": { "style": "asterisk" },
+
+  // Horizontal rule style: dashes
+  "MD035": { "style": "---" },
+
+  // No inline HTML
+  "MD033": true,
+
+  // Heading trailing punctuation — allow question marks
+  "MD026": { "punctuation": ".,;:!" },
+
+  // Table separator style: padded (spaces around dashes)
+  "MD060": { "style": "padded" }
+}
+```
+
+---
+
+## Change Log
+
+| Date       | Version | Author | Summary                                                                                    |
+|------------|---------|--------|--------------------------------------------------------------------------------------------|
+| March 2026 | 1.0     | —      | Initial draft. One-sentence-per-line rule, markdownlint integration, linter configuration. |
+| March 2026 | 1.0     | —      | Promoted to Review status. Content complete.                                               |
+
+---
+
+*This standard governs all Markdown authorship in the Mars Mission Fund project.
+For the engineering quality principles that motivate these rules, see L2-002 (standards/engineering.md).*

--- a/specs/tech/reliability.md
+++ b/specs/tech/reliability.md
@@ -1,0 +1,422 @@
+# Reliability
+
+> **Spec ID**: L3-003
+> **Version**: 1.0
+> **Status**: Approved
+> **Rate of Change**: Sprint-level / tech decisions
+> **Depends On**: L2-002 (standards/engineering.md), L3-001 (tech/architecture.md)
+> **Depended On By**: L3-006, L4-004
+
+---
+
+## Purpose
+
+> **Local demo scope**: Health check contracts and the graceful degradation principles are **real** — the local demo implements health endpoints and handles dependency failures cleanly. Everything else in this spec is theatre: availability targets, SLAs, failover, disaster recovery, on-call rotations, backup verification, and alerting escalation. The local demo runs on a single machine with no redundancy.
+
+This spec governs the availability, resilience, and recoverability of the Mars Mission Fund platform.
+It defines how the system behaves when things go wrong — from a single dependency timeout to a full region failure.
+
+**What this spec covers**:
+
+- Availability targets and SLA definitions.
+- Failover and redundancy strategies.
+- Disaster recovery planning (RPO, RTO).
+- Backup policies and verification.
+- Circuit breaker and bulkhead patterns for external dependency failures.
+- Health check contracts.
+- Graceful degradation modes.
+- Alerting thresholds and escalation policies.
+- Incident classification and response procedures.
+
+**What this spec does NOT cover**:
+
+- Security controls and threat modelling — see [Security](L3-002).
+- Data classification and retention policies — see [Data Management](L3-004).
+- Audit log integrity and immutability — see [Audit](L3-006).
+- Specific infrastructure provider selection — see [Architecture](L3-001).
+
+---
+
+## Inherited Constraints
+
+This spec inherits and implements the following constraints from the [Engineering Standard](L2-002):
+
+- **Section 4.5 — Deployment Gates**: Every deployment must have a rollback plan executable within 15 minutes.
+  Database migrations must be backward-compatible.
+- **Section 6.3 — Health Checks**: Every service must expose liveness and readiness endpoints.
+  Health checks are unauthenticated.
+- **Section 6.4 — Metrics**: Every service must emit the four golden signals (request rate, error rate, latency, saturation).
+- **Section 6.5 — Alerting Baseline**: Every service must define alerts for error rate spikes, latency breaches, and health check failures.
+  This spec defines the thresholds and escalation policies that [Engineering Standard](L2-002), Section 6.5 references.
+- **Section 7.1 — Environment Parity**: Development, staging, and production environments must be structurally identical.
+- **Section 7.4 — Deployments**: Every deployment is automated, reproducible, and reversible.
+
+---
+
+## 1. Availability Targets and SLA Definitions
+
+The [Product Vision & Mission](L1-001) sets a success metric of "100% uptime for financial flows."
+In practice, "100%" means the platform's financial surfaces must meet or exceed 99.99% measured availability per calendar month.
+
+### 1.1 Tiered Availability Targets
+
+| Tier | Description | Availability Target | Max Monthly Downtime | Examples |
+| ---- | ----------- | ------------------- | -------------------- | -------- |
+| Tier 1 — Financial Critical | Flows involving money movement | 99.99% | ~4.3 minutes | Payment processing, escrow operations, disbursements, refunds |
+| Tier 2 — Core Platform | Flows required for primary user journeys | 99.95% | ~21.9 minutes | Authentication, campaign browsing, donor contributions (non-payment steps), KYC submission |
+| Tier 3 — Supporting Services | Flows that enhance experience but are not blocking | 99.9% | ~43.8 minutes | Search, recommendations, notifications, impact dashboards, reporting |
+
+### 1.2 Measurement
+
+- Availability is measured as the percentage of successful requests (HTTP 2xx/3xx) divided by total requests, excluding planned maintenance windows.
+- Planned maintenance windows must be announced at least 72 hours in advance and may not exceed 60 minutes per month.
+- Tier 1 services may not have planned maintenance windows — all maintenance must be performed with zero-downtime deployment techniques.
+
+### 1.3 SLA vs SLO vs SLI
+
+| Term | Definition | Owner |
+| ---- | ---------- | ----- |
+| SLI (Service Level Indicator) | The metric being measured (e.g., request success rate, latency p99) | Engineering team owning the service |
+| SLO (Service Level Objective) | The internal target for each SLI (the targets in Section 1.1) | Engineering leadership |
+| SLA (Service Level Agreement) | The external commitment to users, with consequences for breach | Product and business leadership |
+
+SLOs must be stricter than SLAs.
+The gap between SLO and SLA is the error budget — the margin within which the team can deploy, experiment, and take calculated risks.
+
+**External SLA**: The platform commits to **99% availability** (measured monthly) across all user-facing services.
+This gives a substantial error budget gap — for example, a Tier 1 service with a 99.99% SLO and a 99% SLA has an error budget of ~0.99% of monthly request volume before the external commitment is breached.
+
+---
+
+## 2. Failover Strategies
+
+### 2.1 Failover Architecture
+
+> **Decision**: Active-passive failover topology.
+> Active-passive is simpler to reason about and avoids the data consistency challenges of active-active.
+> Given the scale of this platform, the marginally higher failover time is acceptable.
+> Note: the local demo does not implement failover — this is theatre for production readiness documentation.
+
+### 2.2 Failover Requirements
+
+- **Automatic detection**: Failover must be triggered automatically — no human intervention required to detect a failure and initiate recovery.
+- **Failover time**: Tier 1 services must complete failover within 60 seconds.
+  Tier 2 services within 5 minutes.
+  Tier 3 services within 15 minutes.
+- **Data consistency**: Failover must not result in data loss for committed transactions.
+  In-flight transactions at the moment of failure must be recoverable or safely failed with appropriate user notification.
+- **Failback**: After a failover event, returning to the primary must be a controlled, tested operation — not an automatic bounce-back.
+
+### 2.3 Redundancy Requirements
+
+- No single point of failure exists for Tier 1 or Tier 2 services.
+- Every Tier 1 service runs a minimum of two independent instances at all times.
+- Database and persistent storage for Tier 1 services must have synchronous or near-synchronous replication.
+
+---
+
+## 3. Disaster Recovery
+
+### 3.1 RPO and RTO Targets
+
+| Tier | RPO (Recovery Point Objective) | RTO (Recovery Time Objective) |
+| ---- | ------------------------------ | ----------------------------- |
+| Tier 1 — Financial Critical | 0 (zero data loss for committed transactions) | 15 minutes |
+| Tier 2 — Core Platform | 5 minutes | 30 minutes |
+| Tier 3 — Supporting Services | 1 hour | 4 hours |
+
+### 3.2 Disaster Recovery Plan Requirements
+
+- A documented disaster recovery plan must exist for every Tier 1 and Tier 2 service.
+- The plan must include: trigger conditions, step-by-step recovery procedures, communication templates, and responsible parties.
+- DR plans must be reviewed and updated at least quarterly.
+
+### 3.3 DR Testing
+
+- Full disaster recovery drills must be conducted at least quarterly for Tier 1 services and semi-annually for Tier 2 services.
+- DR drills must be conducted in a production-equivalent environment (per [Engineering Standard](L2-002), Section 7.1).
+- Drill results (actual RPO, actual RTO, issues discovered) must be documented and any gaps remediated before the next drill.
+
+---
+
+## 4. Backup Policies
+
+Backup implementation must coordinate with the data classification and retention policies defined in [Data Management](L3-004).
+
+### 4.1 Backup Frequency
+
+| Data Type | Backup Frequency | Retention Period |
+| --------- | ---------------- | ---------------- |
+| Financial transaction data | Continuous (real-time replication) | As defined in [Data Management](L3-004) — minimum 7 years for financial records |
+| User account data | Every 6 hours | As defined in [Data Management](L3-004) |
+| Campaign data | Every 6 hours | As defined in [Data Management](L3-004) |
+| Audit logs | Continuous (append-only, replicated) | As defined in [Audit](L3-006) |
+| Application configuration | On every change (version-controlled) | Indefinite (in version control) |
+| Infrastructure state | On every change (infrastructure-as-code) | Indefinite (in version control) |
+
+### 4.2 Backup Integrity
+
+- Every backup must be verified via automated integrity checks (checksum validation) immediately after creation.
+- Backup restoration must be tested at least monthly for Tier 1 data and quarterly for Tier 2 data.
+- A backup that has not been tested is not a backup — it is a hope.
+
+### 4.3 Backup Security
+
+- Backups must be encrypted at rest using the same encryption standards as live data (AES-256, per [Engineering Standard](L2-002), Section 1.1).
+- Backup access must be restricted to authorised personnel and logged in the audit trail (per [Audit](L3-006)).
+- Backups must be stored in a geographically separate location from the primary data.
+
+---
+
+## 5. Circuit Breaker Patterns
+
+External dependencies will fail.
+The question is not *if* but *when* and *how gracefully* the platform handles it.
+
+### 5.1 Circuit Breaker Requirements
+
+Every call to an external dependency (payment gateways, KYC providers, email services, search infrastructure) must be wrapped in a circuit breaker.
+
+Circuit breakers must implement three states:
+
+| State | Behaviour |
+| ----- | --------- |
+| **Closed** | Requests pass through normally.  Failures are counted. |
+| **Open** | Requests fail immediately without calling the dependency.  A fallback response is returned. |
+| **Half-Open** | A limited number of probe requests are allowed through to test if the dependency has recovered. |
+
+### 5.2 Circuit Breaker Configuration
+
+> **Note**: Specific threshold values should be tuned per dependency based on observed behaviour.
+> The following are starting defaults:
+
+| Parameter | Default |
+| --------- | ------- |
+| Failure threshold to open | 5 consecutive failures or >50% failure rate over 30 seconds |
+| Open duration before half-open | 30 seconds |
+| Half-open probe count | 3 requests |
+| Success threshold to close | 3 consecutive successes in half-open state |
+| Call timeout | 5 seconds for Tier 1 dependencies, 10 seconds for Tier 2/3 |
+
+### 5.3 Bulkhead Isolation
+
+External dependency calls must be isolated so that a failure in one dependency does not exhaust the resources (threads, connections, memory) available for other operations.
+
+- Each external dependency must have its own connection pool with defined limits.
+- Queue depth limits must be set to prevent unbounded request queueing.
+- Resource exhaustion in one dependency integration must not cascade to other services.
+
+---
+
+## 6. Health Check Contract
+
+Implements [Engineering Standard](L2-002), Section 6.3.
+
+### 6.1 Endpoint Specification
+
+Every service must expose the following health check endpoints:
+
+| Endpoint | Purpose | Authentication |
+| -------- | ------- | -------------- |
+| `GET /health/live` | Liveness — confirms the process is running and can accept TCP connections | None (per [Engineering Standard](L2-002), Section 5.4) |
+| `GET /health/ready` | Readiness — confirms the service and its critical dependencies are functioning | None |
+
+### 6.2 Response Format
+
+```json
+{
+  "status": "healthy | degraded | unhealthy",
+  "service": "<service-name>",
+  "version": "<deployed-version>",
+  "timestamp": "<ISO 8601>",
+  "checks": [
+    {
+      "name": "<dependency-name>",
+      "status": "healthy | degraded | unhealthy",
+      "latency_ms": 12,
+      "message": "<optional human-readable detail>"
+    }
+  ]
+}
+```
+
+### 6.3 Health Check Rules
+
+- Liveness checks must not test downstream dependencies — they confirm only that the process is responsive.
+- Readiness checks must test all critical dependencies (database, cache, essential external services).
+- Health checks must complete within 5 seconds.
+  A health check that times out is treated as unhealthy.
+- Health checks must not have side effects (no writes, no state mutations).
+- A service reporting `degraded` is still accepting traffic but operating with reduced capability (e.g., a non-critical dependency is unavailable).
+
+---
+
+## 7. Graceful Degradation Modes
+
+When a dependency fails, the platform must degrade gracefully rather than fail completely.
+Users must receive clear communication about what is and is not available.
+
+### 7.1 Degradation Scenarios
+
+| Scenario | Impact | Degradation Behaviour |
+| -------- | ------ | --------------------- |
+| **Payment gateway down** | Cannot process new contributions | Display maintenance message on contribution flow.  Existing campaign pages remain browsable.  Queue contribution intents for retry when gateway recovers (with user consent).  Queued intents expire after **2 minutes** — if the gateway has not recovered, the user is notified that their contribution was not processed and invited to try again later. |
+| **KYC provider unreachable** | Cannot verify new identities | Allow account creation to proceed.  Queue KYC verification.  Restrict actions requiring verified identity until verification completes.  Notify user of delay. |
+| **Search infrastructure unavailable** | Cannot search campaigns | Fall back to category browsing and curated collections.  Hide search UI or display "temporarily unavailable" message.  All other platform functions continue normally. |
+| **Email/notification service down** | Cannot send notifications | Queue notifications for retry.  Critical notifications (payment confirmations, security alerts) must have a secondary delivery channel or be surfaced in-app. |
+| **Database read replica down** | Read performance degraded | Route reads to primary (with increased latency).  Monitor primary load.  Alert immediately for capacity planning. |
+| **Cache layer down** | Response times increase | Serve requests directly from database.  Accept higher latency.  Apply rate limiting if database load approaches capacity. |
+
+### 7.2 Degradation Principles
+
+- Users must never see a raw error page.
+  Every failure mode has a designed, branded response (per [Brand Standard](L2-001)).
+- Financial transactions must fail safely — a user must never be charged without confirmation of the contribution being recorded.
+- The system must communicate its state honestly.
+  "Something went wrong" is not acceptable.
+  "Payments are temporarily unavailable — your contribution has not been charged" is.
+
+---
+
+## 8. Alerting and Escalation Policies
+
+Implements [Engineering Standard](L2-002), Section 6.5.
+
+### 8.1 Alert Severity Levels
+
+| Severity | Criteria | Response Time | Notification Channel |
+| -------- | -------- | ------------- | -------------------- |
+| **P1 — Critical** | Tier 1 service is down or data integrity is at risk | Immediate (within 5 minutes) | Page on-call engineer + escalation to engineering leadership |
+| **P2 — High** | Tier 2 service is down or Tier 1 is degraded | Within 15 minutes | Page on-call engineer |
+| **P3 — Medium** | Tier 3 service is down or Tier 2 is degraded, or SLO burn rate is elevated | Within 1 hour | Notify on-call engineer via team channel |
+| **P4 — Low** | Non-urgent anomalies, capacity warnings, approaching thresholds | Next business day | Team channel notification |
+
+### 8.2 Alert Thresholds
+
+These thresholds implement the baseline defined in [Engineering Standard](L2-002), Section 6.5:
+
+| Condition | Threshold | Severity |
+| --------- | --------- | -------- |
+| Error rate exceeds 2x baseline for 5 minutes | Per-service baseline, measured over rolling 7 days | P2 (P1 if Tier 1 service) |
+| p99 latency exceeds SLO for 5 minutes | Per-service SLO target | P2 (P1 if Tier 1 service) |
+| Health check fails 3 consecutive times | Any service | P2 (P1 if Tier 1 service) |
+| Dependency health check failure | Any critical dependency | P3 (P2 if dependency serves Tier 1 flow) |
+| Error budget burn rate >2% per hour | Per-service monthly error budget | P3 |
+| Disk/memory/CPU >85% utilisation for 15 minutes | Any service | P3 |
+| Error budget >50% consumed with >50% of month remaining | Monthly budget calculation | P4 |
+
+### 8.3 Escalation Policy
+
+| Time Since Alert | Action |
+| ---------------- | ------ |
+| 0 minutes | On-call engineer paged |
+| 15 minutes (P1) / 30 minutes (P2) | If not acknowledged, escalate to secondary on-call |
+| 30 minutes (P1) / 1 hour (P2) | If not resolved or actively mitigated, escalate to engineering leadership |
+| 1 hour (P1) | If not resolved, incident commander engaged, status page updated |
+
+### 8.4 On-Call Requirements
+
+- An on-call rotation must be maintained for all Tier 1 and Tier 2 services.
+- On-call engineers must be reachable within 5 minutes and able to begin investigation within 15 minutes.
+- On-call handoff must include a summary of active alerts, recent deployments, and known issues.
+
+---
+
+## 9. Incident Classification and Response
+
+The [Product Vision & Mission](L1-001) sets targets of MTTD (Mean Time to Detect) < 15 minutes and MTTR (Mean Time to Resolve) < 4 hours.
+
+### 9.1 Incident Severity Classification
+
+| Severity | Definition | MTTD Target | MTTR Target |
+| -------- | ---------- | ----------- | ----------- |
+| **SEV-1** | Complete outage of a Tier 1 service, data breach, or financial data integrity issue | < 5 minutes | < 1 hour |
+| **SEV-2** | Partial outage of Tier 1, complete outage of Tier 2, or significant performance degradation affecting users | < 10 minutes | < 2 hours |
+| **SEV-3** | Tier 3 service outage, minor performance degradation, or non-critical feature failure | < 15 minutes | < 4 hours |
+| **SEV-4** | Cosmetic issues, minor bugs, or issues affecting a small number of users | < 1 hour | < 24 hours |
+
+### 9.2 Incident Response Process
+
+1. **Detection** — Automated alerting (Section 8) or user report.
+1. **Triage** — On-call engineer classifies severity and pages additional responders if needed.
+1. **Mitigation** — Immediate actions to restore service (rollback, failover, feature flag disable).
+   Mitigation takes priority over root cause analysis.
+1. **Communication** — Status page update for SEV-1 and SEV-2.
+   Internal stakeholder notification for all severities.
+1. **Resolution** — Root cause identified and permanent fix applied.
+1. **Post-Incident Review** — Blameless post-mortem conducted within 48 hours for SEV-1 and SEV-2, within 1 week for SEV-3.
+
+### 9.3 Post-Incident Review Requirements
+
+- Post-incident reviews are blameless.
+  The goal is to improve the system, not to assign fault.
+- Every review must produce: a timeline, contributing factors, what went well, what could be improved, and concrete action items with owners and due dates.
+- Action items from post-incident reviews are tracked to completion.
+- Recurring incidents indicate a systemic issue and must be escalated to engineering leadership for structural remediation.
+
+---
+
+## Interface Contracts
+
+### With [Architecture](L3-001)
+
+- This spec defines *what* availability and failover targets must be met.
+  [Architecture](L3-001) defines *how* — the infrastructure topology, deployment model, and technology choices that achieve these targets.
+- Health check endpoint paths and response format defined here must be implemented by every service defined in [Architecture](L3-001).
+
+### With [Security](L3-002)
+
+- Incident response for security incidents (data breaches, unauthorised access) follows the process in Section 9, with additional steps defined in [Security](L3-002).
+- Backup encryption requirements (Section 4.3) implement the encryption invariants from [Engineering Standard](L2-002), Section 1.1.
+
+### With [Data Management](L3-004)
+
+- Backup frequency and retention (Section 4) must align with the data classification and retention policies defined in [Data Management](L3-004).
+- RPO targets (Section 3.1) constrain the replication and backup strategies chosen in [Data Management](L3-004).
+
+### With [Audit](L3-006)
+
+- Incident response actions (Section 9) must be logged in the audit trail as defined in [Audit](L3-006).
+- Backup access (Section 4.3) must be audit-logged.
+
+### With [Payments](L4-004)
+
+- Circuit breaker behaviour for payment gateway failures (Section 5) defines the reliability contract that [Payments](L4-004) must implement.
+- Tier 1 availability targets (Section 1.1) apply to all payment flows.
+
+### With [Engineering Standard](L2-002)
+
+- Section 6.3 (Health Checks) — this spec defines the detailed contract.
+- Section 6.5 (Alerting Baseline) — this spec defines the thresholds and escalation policies.
+- Section 4.5 (Deployment Gates) — this spec defines rollback time targets that deployment processes must satisfy.
+
+---
+
+## Resolved Decisions
+
+1. **Active-passive failover** — Active-passive topology selected.
+   Simpler to operate and reason about; the availability trade-off is acceptable at this platform's scale.
+   See Section 2.1.
+1. **Error budget policy enforcement** — Yes. When the monthly error budget for a service is exhausted, non-essential deployments to that service are frozen until the budget replenishes at the start of the next calendar month.
+   Exceptions: security patches and critical bug fixes (SEV-1/SEV-2 remediations) may deploy regardless of error budget status, with engineering leadership approval.
+1. **Status page provider** — [Atlassian Statuspage](https://www.atlassian.com/software/statuspage).
+   Widely adopted, integrates with incident management tooling, and provides subscriber notifications via email and SMS.
+1. **On-call tooling** — [PagerDuty](https://www.pagerduty.com/).
+   Provides paging, escalation policies, on-call scheduling, and integrates with monitoring and status page tooling.
+1. **DR drill scope** — Individual service recovery only.
+   Full region failover drills are disproportionately expensive and complex for the current scale.
+   This decision should be revisited if the platform grows to multi-region deployment.
+1. **Payment queue expiry** — 2 minutes.
+   Queued contribution intents expire after 2 minutes if the payment gateway has not recovered.
+   See Section 7.1 for the full degradation behaviour.
+1. **SLA commitment** — 99% availability (two nines) committed externally.
+   This gives a meaningful gap between the internal SLOs (Section 1.1) and the external SLA, providing a healthy error budget for deployments and experimentation.
+
+---
+
+## Change Log
+
+| Date | Version | Author | Summary |
+| ---- | ------- | ------ | ------- |
+| March 2026 | 0.1 | — | Initial stub. Availability targets (three tiers), failover requirements, DR plan (RPO/RTO), backup policies, circuit breaker patterns, health check contract, graceful degradation modes, alerting and escalation, incident classification and response. |
+| March 2026 | 1.0 | — | All open questions resolved. Active-passive failover, error budget freeze policy, Statuspage, PagerDuty, individual-service DR drills, 2-minute payment queue expiry, 99% external SLA. Promoted to Approved. |

--- a/specs/tech/security.md
+++ b/specs/tech/security.md
@@ -1,0 +1,521 @@
+# Security
+
+> **Spec ID**: L3-002
+> **Version**: 0.4
+> **Status**: Approved
+> **Rate of Change**: Sprint-level / tech decisions
+> **Depends On**: L1-001 (Product Vision & Mission), L2-002 (Engineering Standard), L3-001 (Architecture)
+> **Depended On By**: L3-004 (tech/data-management.md), L3-006 (tech/audit.md), L4-001 (domain/account.md), L4-004 (domain/payments.md), L4-005 (domain/kyc.md)
+
+---
+
+## 1. Purpose
+
+> **Local demo scope**: RBAC model, authentication via Clerk, input validation, CSP headers, and the STRIDE threat model structure are **real** — they inform the local demo's auth implementation. Penetration testing, incident response procedures, breach notification workflows, certificate management, and compliance audit cadences are theatre. Session timeouts and lockout thresholds will use sensible defaults without formal review.
+
+This spec defines the security architecture for Mars Mission Fund: threat model, control matrix, authentication and authorisation architecture, encryption standards, compliance mapping, session management, and incident response.
+It implements the "Security as Foundation" principle from the [Product Vision & Mission](L1-001) and the security invariants defined in the [Engineering Standard](L2-002), Section 1.
+
+**What this spec governs**:
+
+- Threat model and security control matrix.
+- Authentication architecture (OAuth 2.0 / OIDC, MFA).
+- Authorisation architecture (RBAC model, five roles).
+- Encryption standards and certificate management.
+- Session management (token lifecycle, expiry, revocation).
+- Compliance mapping (PCI DSS, GDPR, Australian Privacy Act).
+- Penetration testing and security review cadence.
+- Incident response plan (security-specific).
+- Content Security Policy and security headers.
+
+**What this spec does NOT cover**:
+
+- System topology, service boundaries, and deployment — see [Architecture](L3-001).
+- Data classification, retention, and anonymisation rules — see [Data Management](L3-004).
+- Audit event schemas, log immutability, and retention — see [Audit](L3-006).
+- Availability targets, failover, and operational incident response — see [Reliability](L3-003).
+- Domain-specific payment security (PCI DSS SAQ-A boundary details) — see [Payments](L4-004).
+- KYC document handling and identity verification — see [KYC](L4-005).
+
+---
+
+## 2. Inherited Constraints
+
+This spec inherits all constraints from the [Engineering Standard](L2-002).
+The following sections are directly implemented by this spec:
+
+| L2-002 Section | Constraint | How This Spec Implements It |
+| --- | --- | --- |
+| 1.1 Encryption | TLS 1.3 minimum; AES-256 at rest for sensitive data | Section 6 defines encryption standards, key management, and certificate lifecycle |
+| 1.2 Data Access | Parameterised queries only | Inherited by all services; enforced by data access layer defined in [Architecture](L3-001), Section 4.2 |
+| 1.3 Secrets Management | Secrets via dedicated service, injected at runtime | Section 6.3 defines secret handling requirements; technology choice recorded in [Architecture](L3-001), Section 8 |
+| 1.4 Input Validation | All external input validated at system boundary; CSP headers mandatory | Section 7 defines CSP policy and input validation standards |
+| 1.5 Authentication & Authorisation | Every endpoint authenticated; MFA for financial and admin operations | Sections 4 and 5 define the full authentication and authorisation architecture |
+| 1.6 Dependency Security | Vulnerability scanning on every build; CVE response SLAs | Section 11 defines security review cadence and dependency scanning integration |
+| 1.7 Logging & Auditability | Every state mutation logged; sensitive data never logged | Jointly implemented with [Audit](L3-006); this spec defines what constitutes a security-relevant event |
+
+This spec also inherits from [Architecture](L3-001):
+
+| L3-001 Section | Constraint | How This Spec Implements It |
+| --- | --- | --- |
+| 3.2 API Gateway | TLS termination and token validation at the gateway | Section 4.3 defines token validation rules at the gateway |
+| 6.3 Service Identity | Every service-to-service call authenticated | Section 5.4 defines the service identity trust model |
+
+---
+
+## 3. Threat Model
+
+This section uses the STRIDE framework to categorise threats against Mars Mission Fund.
+The threat model is a living document — it must be reviewed and updated whenever the system architecture changes or a new domain is added.
+
+### 3.1 Threat Categories
+
+| STRIDE Category | Description | Primary Targets |
+| --- | --- | --- |
+| **Spoofing** | An attacker impersonates a legitimate user, service, or system component | Authentication endpoints, service-to-service calls, API Gateway |
+| **Tampering** | An attacker modifies data in transit or at rest | Payment transactions, campaign data, escrow balances, KYC documents |
+| **Repudiation** | An actor denies performing an action, and the system cannot prove otherwise | Financial transactions, campaign approvals, disbursement authorisations, admin operations |
+| **Information Disclosure** | Sensitive data is exposed to unauthorised parties | PII, financial data, KYC documents, authentication credentials, audit logs |
+| **Denial of Service** | An attacker degrades or prevents legitimate access to the platform | API Gateway, authentication service, payment processing |
+| **Elevation of Privilege** | An attacker gains access to resources or operations beyond their authorised role | Role assignment, admin endpoints, campaign review pipeline, disbursement approval |
+
+### 3.2 Trust Boundaries
+
+| Boundary | Description | Controls |
+| --- | --- | --- |
+| External → API Gateway | All traffic from end users, external APIs, webhooks | TLS 1.3, authentication, rate limiting, input validation, CSP headers |
+| API Gateway → Domain Services | Validated requests forwarded to internal services | Token validation, correlation ID propagation, authorisation enforcement |
+| Service → Service | Inter-service communication within the platform | Service identity authentication (see Section 5.4), authorisation policies |
+| Service → External Provider | Calls to payment gateway, KYC provider, email service | Adapter abstraction per [Architecture](L3-001), Section 3.3; TLS 1.3; credential isolation |
+| Service → Data Store | Database and object storage access | Data access layer enforcement, parameterised queries, encryption at rest |
+| Audit boundary | Audit log ingestion and storage | Append-only writes, no delete/modify capability — see [Audit](L3-006) |
+
+### 3.3 Security Control Matrix
+
+| Threat | Trust Boundary | Control | Spec Reference | Priority |
+| --- | --- | --- | --- | --- |
+| **Spoofing** | | | | |
+| User impersonation | External → API Gateway | OAuth 2.0 / OIDC authentication via Clerk with MFA | Section 4 | Critical |
+| Session hijacking | External → API Gateway | Short-lived access tokens (5 min), secure HttpOnly cookies, session binding to device/user-agent | Section 4.3, 4.4 | Critical |
+| Credential stuffing | External → API Gateway | Account lockout after 3 failed attempts, rate limiting on auth endpoints (10/min) | Section 4.5, 7.3 | Critical |
+| Token forgery | API Gateway → Domain Services | RS256/ES256 JWT signature validation, issuer and expiry checks at gateway | Section 4.3 | Critical |
+| Service impersonation | Service → Service | Not applicable in current single-unit deployment; JWT service tokens if services are split | Section 5.4, [Architecture](L3-001) | Critical |
+| Webhook spoofing | Service → External Provider | Stripe webhook signature verification (HMAC-SHA256) before processing | [Payments](L4-004), Section 3.3 | Critical |
+| **Tampering** | | | | |
+| Payment manipulation | Service → External Provider | Stripe tokenisation — platform never handles raw card data; signed API requests | [Payments](L4-004) | Critical |
+| Data at rest modification | Service → Data Store | AES-256 encryption at rest via AWS KMS; envelope encryption with DEK/KEK | Section 6.1 | Critical |
+| Data in transit interception | All boundaries | TLS 1.3 minimum on all connections, including internal service communication | Section 6.2 | Critical |
+| Escrow ledger manipulation | Service → Data Store | Append-only immutable ledger; double-entry bookkeeping; daily reconciliation against Stripe | [Payments](L4-004), [Audit](L3-006) | Critical |
+| Request parameter tampering | External → API Gateway | Input validation at system boundary; allowlist validation; Zod schema enforcement | Section 7.1 | High |
+| **Repudiation** | | | | |
+| Financial action denial | All internal boundaries | Immutable audit logging of all payment state mutations with actor, timestamp, correlation ID | [Audit](L3-006) | Critical |
+| Role change denial | API Gateway → Domain Services | Security-critical audit events for all role assignments and changes | Section 5.2, [Audit](L3-006) | Critical |
+| Campaign approval denial | API Gateway → Domain Services | Audit trail for all campaign review decisions with reviewer identity | [Audit](L3-006) | High |
+| Disbursement approval denial | API Gateway → Domain Services | Dual-approval workflow with independent audit entries per approver | [Payments](L4-004), Section 7.2 | Critical |
+| **Information Disclosure** | | | | |
+| PII exposure | All boundaries | Data classification scheme; field-level encryption for sensitive fields; log sanitisation | Section 6, [Data Management](L3-004) | Critical |
+| Card data exposure | External → API Gateway | SAQ-A scope — card data never enters platform; Stripe Elements handles client-side | [Payments](L4-004), Section 8.1 | Critical |
+| KYC document exposure | Service → Data Store | Encrypted at rest (AES-256); access restricted to KYC service; access logged | [KYC](L4-005), Section 6.1 | Critical |
+| Credential leakage | All boundaries | Secrets managed via AWS KMS; injected at runtime; never logged, committed, or passed as CLI args | Section 6.3 | Critical |
+| Error message information leak | External → API Gateway | Generic error responses to external clients; detailed errors logged internally only | Section 7.1 | Medium |
+| Referrer leakage | External → API Gateway | `Referrer-Policy: strict-origin-when-cross-origin` header | Section 7.2 | Medium |
+| **Denial of Service** | | | | |
+| API flooding | External → API Gateway | Rate limiting: 100/min general, 10/min auth, 20/min financial; `Retry-After` headers | Section 7.3 | High |
+| Authentication endpoint abuse | External → API Gateway | Stricter rate limits on auth endpoints; account lockout with escalating duration | Section 4.5, 7.3 | High |
+| Resource exhaustion via file upload | External → API Gateway | File type validation (magic bytes), size limits, storage in separate domain | Section 7.1 | High |
+| **Elevation of Privilege** | | | | |
+| Unauthorised role assignment | API Gateway → Domain Services | RBAC enforcement; Reviewer/Admin assigned by Admin; Super Admin by Super Admin only with MFA | Section 5.2 | Critical |
+| Horizontal privilege escalation | API Gateway → Domain Services | Resource-level authorisation in domain services (e.g., creators manage only own campaigns) | Section 5.3 | Critical |
+| Vertical privilege escalation | API Gateway → Domain Services | API-layer authorisation on every request; role claims validated from access token | Section 5.3 | Critical |
+| UI-only access control bypass | External → API Gateway | Authorisation enforced at API layer, not UI; UI role-based hiding is cosmetic only | Section 5.3 | Critical |
+| MFA bypass on privileged actions | API Gateway → Domain Services | MFA required for all financial actions, admin operations, and account recovery | Section 4.2 | Critical |
+
+---
+
+## 4. Authentication Architecture
+
+### 4.1 Protocol
+
+Authentication is based on OAuth 2.0 with OpenID Connect (OIDC) for identity.
+
+- **Identity Provider (IdP)**: Clerk (per [Tech Stack](L3-008)).
+  Clerk provides OAuth 2.0/OIDC, session management, and MFA capabilities as a managed service.
+- All user authentication flows use the Authorization Code flow with PKCE (Proof Key for Code Exchange).
+- Implicit flow and Resource Owner Password Credentials flow are prohibited.
+
+### 4.2 Multi-Factor Authentication (MFA)
+
+Per [Engineering Standard](L2-002), Section 1.5, MFA is required for:
+
+- All financial actions (contributions, disbursements, refunds).
+- All administrative operations (role assignment, campaign approval, system configuration).
+- Account recovery.
+- Changes to authentication settings (password change, MFA method change).
+
+Supported MFA methods:
+
+| Method | Use Case | Notes |
+| --- | --- | --- |
+| TOTP (Time-Based One-Time Password) | Primary MFA method for all users | MUST comply with RFC 6238; 30-second time step; SHA-256 minimum |
+| WebAuthn / FIDO2 | Recommended for administrative and high-privilege users | Hardware security keys and platform authenticators supported |
+| Recovery codes | Account recovery when primary MFA is unavailable | Single-use; 10 codes generated at MFA enrolment; stored hashed |
+
+SMS-based OTP is not supported as an MFA method due to known vulnerabilities (SIM swapping, SS7 attacks).
+
+### 4.3 Token Architecture
+
+| Token Type | Purpose | Lifetime | Storage |
+| --- | --- | --- | --- |
+| Access token | Authorises API requests | 5 minutes | Memory only (never persisted to disk or local storage) |
+| Refresh token | Obtains new access tokens without re-authentication | 1 day | Secure, HttpOnly cookie; server-side reference validated against revocation list |
+| ID token | Carries identity claims (OIDC) | Same as access token | Memory only |
+
+- Access tokens are JWTs signed with RS256 (minimum 2048-bit RSA) or ES256.
+- The API Gateway validates token signatures, expiry, and issuer before forwarding requests to domain services per [Architecture](L3-001), Section 3.2.
+- Tokens include the user's role claims for authorisation enforcement (see Section 5).
+
+### 4.4 Session Management
+
+- Sessions are bound to a single device/user-agent.
+- Concurrent session limit: unlimited. Users may have any number of active sessions across devices.
+- Session revocation is immediate upon: password change, MFA method change, account deactivation, explicit logout, or administrator-initiated revocation.
+- Idle session timeout: 15 minutes of inactivity.
+- Absolute session timeout: 8 hours regardless of activity.
+- All active sessions are visible to the user in their account settings, with the ability to revoke individual sessions.
+
+### 4.5 Account Lockout
+
+- After 3 consecutive failed authentication attempts, the account is temporarily locked.
+- Lockout duration escalates with repeated lockouts (e.g., 5 minutes, 15 minutes, 1 hour).
+- Account lockout events are logged as security events and trigger alerts per [Audit](L3-006).
+- Lockout resets after successful authentication or administrator intervention.
+- Lockout applies per-account, not per-IP, to prevent credential stuffing without enabling account denial-of-service at the IP level.
+
+---
+
+## 5. Authorisation Architecture
+
+### 5.1 RBAC Model
+
+Mars Mission Fund uses Role-Based Access Control (RBAC) with five roles defined in the [Product Vision & Mission](L1-001):
+
+| Role | Description | Typical Capabilities |
+| --- | --- | --- |
+| **Backer** | A user who contributes funds to campaigns | Browse campaigns, make contributions, view own contribution history, manage own profile |
+| **Creator** | A user who creates and manages campaigns | All Backer capabilities + create campaigns, manage own campaigns, define milestones, request disbursements |
+| **Reviewer** | A user who reviews and approves/rejects campaigns | All Backer capabilities + review submitted campaigns, approve/reject, request changes |
+| **Administrator** | A user who manages platform operations | All Reviewer capabilities + manage users, assign roles (except Super Administrator), view audit logs, manage platform settings |
+| **Super Administrator** | Highest-privilege platform user | All Administrator capabilities + assign Administrator/Super Administrator roles, access compliance reports, manage security settings |
+
+### 5.2 Role Assignment Rules
+
+- New users are assigned the Backer role by default upon registration.
+- Creator role is granted after KYC verification — see [KYC](L4-005).
+- Reviewer role is assigned by an Administrator or Super Administrator.
+- Administrator role is assigned by a Super Administrator only.
+- Super Administrator role is assigned by another Super Administrator only, with MFA confirmation from both parties.
+- Role changes are logged as security-critical audit events per [Audit](L3-006).
+
+### 5.3 Permission Enforcement
+
+- Authorisation is enforced at the API layer, not the UI layer.
+  The UI may hide elements based on role, but the API must independently validate permissions on every request.
+- Permissions are evaluated against the role claims in the access token (Section 4.3).
+- Resource-level authorisation (e.g., "this Creator can only manage their own campaigns") is enforced by the domain service, not the API Gateway.
+- All authorisation failures are logged with: actor identity, requested resource, requested action, and the reason for denial.
+
+### 5.4 Service-to-Service Authorisation
+
+- Each service has a unique identity per [Architecture](L3-001), Section 6.3.
+- Per [Architecture](L3-001), the current deployment is a single unit, making service-to-service authentication not applicable. If services are split in future, JWT service tokens are the recommended mechanism (see [Architecture](L3-001), Open Question 6).
+- Service authorisation policies follow the principle of least privilege: each service is authorised only for the specific endpoints it needs to call.
+- Service authorisation policies are defined declaratively and version-controlled.
+
+---
+
+## 6. Encryption Standards
+
+### 6.1 Encryption at Rest
+
+Per [Engineering Standard](L2-002), Section 1.1:
+
+- All sensitive data is encrypted at rest using AES-256.
+- "Sensitive data" classification is defined in [Data Management](L3-004).
+  At minimum: PII, financial data, authentication credentials, KYC documents.
+- Encryption key management: AWS KMS. Note: this is a workshop project and will not reach production; AWS KMS is selected for consistency with the AWS-based tech stack.
+- Key rotation policy: encryption keys must be rotated at least annually, or immediately upon suspected compromise.
+- Envelope encryption is used where supported: data is encrypted with a data encryption key (DEK), and the DEK is encrypted with a key encryption key (KEK) managed by the KMS.
+
+### 6.2 Encryption in Transit
+
+Per [Engineering Standard](L2-002), Section 1.1:
+
+- All communication uses TLS 1.3 (minimum).
+  TLS 1.0, 1.1, and 1.2 are not supported.
+- No exceptions for internal service-to-service communication.
+- TLS termination occurs at the API Gateway for external traffic per [Architecture](L3-001), Section 3.2.
+- Internal service-to-service communication uses TLS regardless of whether a service mesh provides it — defence in depth.
+- Certificate management: AWS Certificate Manager (ACM) for automated certificate provisioning and renewal.
+
+### 6.3 Secrets Management
+
+Per [Engineering Standard](L2-002), Sections 1.3 and 7.3:
+
+- All secrets (API keys, database credentials, encryption keys, signing certificates) are managed through the secrets management service recorded in [Architecture](L3-001), Section 8.
+- Secrets are injected at runtime via environment variables.
+- Secrets are never committed to version control, logged, passed as CLI arguments, or written to disk by application code.
+- Secret rotation must be possible without application redeployment.
+- Applications must handle secret rotation gracefully (re-read on expiry, not crash).
+- Secret access is logged as an audit event.
+
+---
+
+## 7. Input Validation & Security Headers
+
+### 7.1 Input Validation
+
+Per [Engineering Standard](L2-002), Section 1.4:
+
+- All external input is validated, sanitised, and type-checked at the system boundary before any processing.
+- "External" includes: user input, API requests, webhook payloads, file uploads, URL parameters, and any data originating outside the trust boundary.
+- Validation rules:
+  - Accept-list (allowlist) validation is preferred over deny-list (blocklist).
+  - String inputs are length-limited and character-set restricted where the domain allows.
+  - Numeric inputs are range-checked.
+  - File uploads are validated for type (magic bytes, not just extension), size, and content.
+  - Uploaded files are stored in a separate domain from the application per [Engineering Standard](L2-002), Section 1.4.
+
+### 7.2 Security Headers
+
+All web responses must include the following security headers:
+
+| Header | Value | Purpose |
+| --- | --- | --- |
+| `Content-Security-Policy` | `default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://*.clerk.accounts.dev; frame-ancestors 'none'; base-uri 'self'; form-action 'self'` | Mitigate XSS and data injection |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` | Enforce HTTPS |
+| `X-Content-Type-Options` | `nosniff` | Prevent MIME-type sniffing |
+| `X-Frame-Options` | `DENY` | Prevent clickjacking |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Control referrer information leakage |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=()` | Restrict browser feature access |
+| `Cache-Control` | `no-store` for authenticated responses | Prevent caching of sensitive data |
+
+### 7.3 Rate Limiting
+
+- Rate limiting is enforced at the API Gateway per [Architecture](L3-001), Section 3.2.
+- Rate limits apply per-user (authenticated) and per-IP (unauthenticated pre-auth endpoints).
+- Rate limit thresholds (per user or per IP for unauthenticated endpoints):
+  - General API endpoints: 100 requests per minute.
+  - Authentication endpoints (login, register, password reset): 10 requests per minute.
+  - Financial action endpoints (contribute, disburse, refund): 20 requests per minute.
+  - These thresholds are sized for a B2C application serving tens to low thousands of users.
+- Authentication endpoints have stricter rate limits to mitigate brute-force attacks.
+- Rate limit responses include `Retry-After` headers per HTTP standards.
+
+---
+
+## 8. Compliance Mapping
+
+### 8.1 PCI DSS
+
+Mars Mission Fund targets **SAQ-A** compliance scope by delegating all cardholder data handling to the payment gateway.
+
+Payment gateway: **Stripe** (per [Payments](L4-004) and [Tech Stack](L3-008)).
+Client-side tokenisation via **Stripe Elements** — the platform never stores, processes, or transmits raw cardholder data.
+
+| SAQ-A Requirement | Implementation | Spec Reference |
+| --- | --- | --- |
+| **2.1** — No cardholder data stored, processed, or transmitted by MMF systems | All card data handled by Stripe Elements client-side; platform receives only Stripe payment method tokens | [Payments](L4-004), Section 4 |
+| **2.2** — All payment pages delivered via HTTPS | TLS 1.3 enforced on all connections; HSTS with preload | Section 6.2, 7.2 |
+| **3.1** — Restrict inbound traffic to necessary connections | API Gateway rate limiting; firewall rules restrict ingress to HTTPS only | Section 7.3, [Architecture](L3-001) |
+| **3.2** — Restrict outbound traffic to payment processor | Stripe API calls via adapter; outbound restricted to Stripe API endpoints and other declared external providers | [Payments](L4-004), [Architecture](L3-001) |
+| **6.1** — Security patches applied in timely manner | Dependency vulnerability scanning on every CI build; CVSS 9.0+ blocks merge | Section 11 |
+| **6.2** — Protection against known vulnerabilities | SAST on every CI build; DAST weekly in staging; bi-annual penetration testing | Section 11 |
+| **7.1** — Restrict access to system components and cardholder data | RBAC with five roles; MFA for financial and admin operations; API-layer authorisation | Sections 4, 5 |
+| **7.2** — Unique ID for each person with access | Clerk-managed user identities; no shared or generic accounts | Section 4.1 |
+| **8.1** — Identify and authenticate access to system components | OAuth 2.0 / OIDC authentication; MFA on financial actions | Section 4 |
+| **9.1** — Physical security of payment processing areas | Not applicable — no cardholder data processed or stored in MMF infrastructure | N/A |
+| **11.1** — Test security systems and processes regularly | Security review cadence: SAST/DAST continuous, penetration testing bi-annually, threat model review quarterly | Section 11 |
+| **11.2** — Maintain an information security policy | This spec (L3-002) serves as the security policy; reviewed on architectural change or quarterly | This spec |
+| **12.1** — Monitor all access to network resources and cardholder data | Immutable audit logs for all payment-related events; all authorisation failures logged | [Audit](L3-006), Section 5.3 |
+
+Jointly owned with [Payments](L4-004).
+
+### 8.2 GDPR
+
+| GDPR Right / Obligation | Implementation | Spec Reference |
+| --- | --- | --- |
+| Lawful basis for processing | Consent management and contractual necessity documented per data type | [Data Management](L3-004) |
+| Right to access (Art. 15) | Data export API for user's own data | [Account](L4-001) |
+| Right to erasure (Art. 17) | Anonymisation workflow; retention overrides for legal obligations | [Data Management](L3-004) |
+| Right to rectification (Art. 16) | Profile editing; corrections to KYC data via re-submission | [Account](L4-001), [KYC](L4-005) |
+| Data portability (Art. 20) | Machine-readable export of user-provided data | [Account](L4-001) |
+| Breach notification (Art. 33, 34) | 72-hour notification process | Section 10.3 |
+| Data protection by design (Art. 25) | Encryption at rest and in transit, field-level encryption, access control | Sections 5, 6 |
+| Data Protection Impact Assessment (DPIA) | Required for KYC processing, payment processing, profiling | [KYC](L4-005), [Payments](L4-004) |
+
+### 8.3 Australian Privacy Act
+
+| Principle | Implementation | Spec Reference |
+| --- | --- | --- |
+| APP 1 — Open and transparent management | Privacy policy, data handling documentation | [Data Management](L3-004) |
+| APP 3 — Collection of solicited personal information | Collect only what is necessary for platform functions | [Account](L4-001), [KYC](L4-005) |
+| APP 6 — Use or disclosure | Data used only for the purpose it was collected | [Data Management](L3-004) |
+| APP 8 — Cross-border disclosure | Data residency and transfer controls | [Data Management](L3-004) |
+| APP 11 — Security of personal information | Encryption, access control, secure destruction | Sections 5, 6 |
+| APP 12 — Access to personal information | User data access and export | [Account](L4-001) |
+| APP 13 — Correction of personal information | Profile editing and correction workflows | [Account](L4-001) |
+| Notifiable Data Breaches scheme | Mandatory breach notification to OAIC | Section 10.3 |
+
+---
+
+## 9. Session Management
+
+> This section expands on the token and session architecture defined in Section 4.3 and 4.4.
+
+### 9.1 Token Lifecycle
+
+```text
+[User authenticates] → [Access token + Refresh token issued]
+        │
+        ├── Access token expires → [Refresh token used to obtain new access token]
+        │                                   │
+        │                                   ├── Refresh token valid → [New access + refresh token pair issued]
+        │                                   └── Refresh token expired/revoked → [Re-authentication required]
+        │
+        ├── Security event (password change, MFA change) → [All tokens revoked; re-authentication required]
+        │
+        └── Explicit logout → [Access + refresh tokens revoked]
+```
+
+### 9.2 Token Revocation
+
+- A server-side revocation list (or equivalent mechanism) tracks revoked tokens.
+- The API Gateway checks the revocation list on every request.
+- Revocation is propagated within 30 seconds across all gateway instances.
+- Revocation events are logged as security audit events per [Audit](L3-006).
+
+### 9.3 Refresh Token Rotation
+
+- Refresh tokens are rotated on every use: when a refresh token is exchanged for a new access token, a new refresh token is also issued and the previous one is invalidated.
+- If a previously invalidated refresh token is presented, all tokens for that session are revoked (potential token theft detected).
+
+---
+
+## 10. Incident Response Plan
+
+This section covers security-specific incident response.
+Operational incident response (availability, performance degradation) is defined in [Reliability](L3-003).
+
+### 10.1 Severity Classification
+
+| Severity | Description | Examples | Response Time |
+| --- | --- | --- | --- |
+| **Critical** | Active breach, data exfiltration, or exploitation in progress | Unauthorised access to PII or financial data, payment system compromise, credential leak | Immediate (within 15 minutes) |
+| **High** | Confirmed vulnerability being actively exploited or high likelihood of imminent exploitation | Unpatched critical CVE in production, privilege escalation vulnerability discovered | Within 1 hour |
+| **Medium** | Vulnerability identified, not yet exploited; security control degradation | Failed penetration test finding, misconfigured security header, expired certificate | Within 24 hours |
+| **Low** | Minor security improvement or hardening opportunity | Non-critical dependency update, security best practice recommendation | Within 1 sprint |
+
+### 10.2 Response Process
+
+1. **Detection & Triage**: Security event detected via monitoring, audit log analysis, or external report.
+   Assign severity.
+   Notify the security incident response team.
+1. **Containment**: Isolate affected systems.
+   Revoke compromised credentials.
+   Block malicious actors at the network edge.
+1. **Investigation**: Determine scope of impact, root cause, and affected data/users.
+   Preserve forensic evidence (logs, snapshots).
+1. **Remediation**: Fix the vulnerability or close the attack vector.
+   Deploy patches.
+   Rotate affected secrets.
+1. **Recovery**: Restore affected services to normal operation.
+   Verify integrity of affected data.
+1. **Post-incident review**: Conduct a blameless post-mortem within 5 business days.
+   Document findings, root cause, and preventive actions.
+   Update threat model (Section 3) if new threats were identified.
+
+### 10.3 Breach Notification
+
+- **GDPR (Art. 33)**: Supervisory authority notified within 72 hours of becoming aware of a breach involving personal data.
+- **GDPR (Art. 34)**: Affected individuals notified without undue delay if breach is likely to result in high risk.
+- **Australian Notifiable Data Breaches scheme**: OAIC and affected individuals notified as soon as practicable after becoming aware of an eligible data breach.
+- Notification templates are maintained in the incident response runbook and include: affected data summary, remediation steps taken, contact information for further enquiries, and regulatory body references.
+- Escalation chain: Engineering Lead → Security Lead → CTO → Legal Counsel → CEO. All escalation contacts are maintained in an internal directory with backup contacts.
+
+---
+
+## 11. Security Review & Testing Cadence
+
+| Activity | Frequency | Scope | Output |
+| --- | --- | --- | --- |
+| Dependency vulnerability scan | Every CI build | All direct and transitive dependencies | Automated; blocks merge for CVSS 9.0+ per [Engineering Standard](L2-002), Section 1.6 |
+| Static application security testing (SAST) | Every CI build | All application code | Automated; integrated into CI pipeline |
+| Dynamic application security testing (DAST) | Weekly in staging | Running application in staging environment | Automated scan report |
+| Penetration test — external | Bi-annually | External attack surface | Third-party report; findings triaged by severity |
+| Penetration test — internal | Bi-annually | Internal services, privilege escalation, lateral movement | Third-party report |
+| Threat model review | On architectural change or quarterly (whichever is sooner) | Section 3 of this spec | Updated threat model |
+| Security code review | Every PR touching security surfaces | Authentication, authorisation, payment flows, encryption, data access | Second reviewer with security domain expertise per [Engineering Standard](L2-002), Section 3.4 |
+| Secret rotation audit | Quarterly | All secrets in the secrets management service | Verification that rotation policies are followed |
+| Compliance review | Annually | PCI DSS SAQ-A, GDPR, Australian Privacy Act | Compliance report |
+
+---
+
+## 12. Interface Contracts
+
+### 12.1 Security <> Architecture (L3-001)
+
+- [Architecture](L3-001) defines the service topology, API Gateway, and communication patterns.
+  This spec defines the authentication/authorisation mechanisms, token formats, and encryption that operate within that topology.
+- [Architecture](L3-001) defines the API Gateway as the TLS termination and token validation point.
+  This spec defines the token format, validation rules, and MFA enforcement at the gateway.
+- Service identity mechanism is jointly owned: [Architecture](L3-001) defines the pattern; this spec defines the credentials, trust model, and authorisation policies.
+- Reference: [Architecture](L3-001), Section 11.1.
+
+### 12.2 Security <> Data Management (L3-004)
+
+- This spec defines encryption standards and access controls.
+  [Data Management](L3-004) defines the data classification scheme that determines which data requires encryption and at what level.
+- GDPR compliance mapping (Section 8.2) references data retention, anonymisation, and data lifecycle policies owned by [Data Management](L3-004).
+- Data access logging requirements are jointly owned: this spec defines what constitutes a security-relevant access event; [Data Management](L3-004) defines access patterns per classification level.
+
+### 12.3 Security <> Audit (L3-006)
+
+- This spec defines which events are security-critical and must be logged (authentication attempts, authorisation failures, role changes, token revocations, security incidents).
+- [Audit](L3-006) defines the immutable logging architecture, event schema, retention policies, and access controls on audit data.
+- Incident response (Section 10) depends on audit log availability and integrity guaranteed by [Audit](L3-006).
+
+### 12.4 Security <> Reliability (L3-003)
+
+- Incident response is split: this spec owns security incident response (Section 10); [Reliability](L3-003) owns operational incident response.
+- DDoS mitigation and rate limiting (Section 7.3) overlap with availability protection defined in [Reliability](L3-003).
+
+### 12.5 Security <> Account (L4-001)
+
+- This spec defines the authentication and session architecture.
+  [Account](L4-001) implements the user-facing registration, login, MFA enrolment, password management, and session visibility workflows.
+- Role assignment rules (Section 5.2) are enforced by [Account](L4-001).
+
+### 12.6 Security <> Payments (L4-004)
+
+- This spec defines the PCI DSS SAQ-A compliance boundary (Section 8.1).
+  [Payments](L4-004) implements the payment tokenisation, gateway integration, and cardholder data isolation that maintain that boundary.
+- MFA requirement for financial actions (Section 4.2) is enforced in payment flows defined by [Payments](L4-004).
+
+### 12.7 Security <> KYC (L4-005)
+
+- This spec defines encryption and access control requirements for identity documents.
+  [KYC](L4-005) implements the document handling, storage, and verification workflows.
+- Creator role grant depends on KYC verification (Section 5.2).
+  [KYC](L4-005) defines the verification lifecycle and triggers.
+- GDPR and Australian Privacy Act compliance for identity data is jointly owned between this spec, [Data Management](L3-004), and [KYC](L4-005).
+
+---
+
+## 13. Change Log
+
+| Date | Version | Author | Summary |
+| --- | --- | --- | --- |
+| March 2026 | 0.1 | — | Initial stub. STRIDE threat model, security control matrix, OAuth 2.0/OIDC authentication, RBAC with five roles, encryption standards, session management, PCI DSS/GDPR/Australian Privacy Act compliance mapping, incident response plan, security review cadence. |
+| March 2026 | 0.2 | — | Resolved OQ-1: Clerk selected as Identity Provider per L3-008. |
+| March 2026 | 0.3 | — | Resolved all remaining open questions (OQ-2 through OQ-14). Access token 5 min, refresh token 1 day, unlimited sessions, 15 min idle / 8 hr absolute timeout, 3-attempt lockout, AWS KMS + ACM, CSP directives, rate limits, 30s revocation propagation, bi-annual pen testing, breach notification escalation chain. Status moved to Review. |
+| March 2026 | 0.4 | — | Expanded Security Control Matrix (Section 3.3) with comprehensive controls across all STRIDE categories and trust boundaries. Expanded PCI DSS SAQ-A mapping (Section 8.1) for Stripe gateway. Removed placeholder notes. |

--- a/specs/tech/tech-stack.md
+++ b/specs/tech/tech-stack.md
@@ -1,0 +1,250 @@
+# Tech Stack
+
+> **Spec ID:** L3-008
+> **Version:** 0.1.0
+> **Status:** Approved
+> **Rate of change:** Slow (changes at major technology decisions)
+> **Depends on:** L1-001, L2-002, L3-001
+> **Depended on by:** All L3 and L4 specs (technology baseline)
+
+---
+
+## Purpose
+
+> **Local demo scope**: All technology choices in this document are **real** and used in the local demo. Cloud infrastructure (ECS Fargate, CloudFront, ECR, Terraform Cloud) is replaced by Docker Compose for local development. The local demo uses the same languages, frameworks, and libraries listed here.
+
+This document enumerates the technology choices for the Mars Mission Fund platform.
+It serves as the single source of truth for languages, frameworks, libraries, infrastructure, and tooling.
+
+---
+
+## Runtime & Language
+
+| Technology | Version | Purpose |
+| ---------- | ------- | ------- |
+| Node.js | 22.x LTS | Server and build runtime |
+| npm | 10.x | Package management |
+| TypeScript | Latest stable | Primary language (frontend and backend) |
+
+---
+
+## Frontend
+
+| Technology | Version | Purpose |
+| ---------- | ------- | ------- |
+| React | 19.x | Single-page application (SPA) framework |
+| Vite | Latest stable | Build tool and dev server |
+| TanStack Query (React Query) | v5 | Server state management (data fetching, caching, mutations) |
+| React Router | v7 | Client-side routing |
+| Tailwind CSS | v4 | Utility-first CSS framework |
+| PostHog (posthog-js) | Latest stable | Feature flags, product analytics, and web analytics |
+
+---
+
+## Backend
+
+| Technology | Version | Purpose |
+| ---------- | ------- | ------- |
+| Express | 5.x | HTTP server framework |
+| Pino | Latest stable | Structured JSON logging |
+| pino-http | Latest stable | HTTP request logging middleware |
+| pino-pretty | Latest stable | Human-readable log output (development only) |
+| PostHog (posthog-node) | Latest stable | Server-side feature flag evaluation and event capture |
+
+---
+
+## Feature Flags & Product Operations
+
+| Technology | Purpose |
+| ---------- | ------- |
+| PostHog | Unified platform for feature flags, product analytics, and web analytics |
+| posthog-js | Client-side SDK — feature flags, analytics, and session replay |
+| posthog-node | Server-side SDK — feature flag evaluation and event capture from backend services |
+
+PostHog is the single platform for all feature flag management and product analytics.
+Feature flags are runtime-configurable without deployment (see [Architecture](L3-001), Section 9).
+
+---
+
+## Developer Observability
+
+| Technology | Purpose |
+| ---------- | ------- |
+| Pino | Structured JSON application logging |
+| AWS CloudWatch | Infrastructure metrics, log aggregation, and alerting |
+
+Pino handles structured application logging (see Backend section).
+CloudWatch provides infrastructure-level metrics, centralised log storage, and alerting.
+Together they form the developer observability stack, complementing PostHog's product analytics.
+
+---
+
+## Validation
+
+| Technology | Purpose |
+| ---------- | ------- |
+| Zod | Runtime schema validation, shared between frontend and backend |
+
+---
+
+## Authentication
+
+| Technology | Purpose |
+| ---------- | ------- |
+| Clerk | Client-side authentication and user management |
+
+---
+
+## Payments
+
+| Technology | Purpose |
+| ---------- | ------- |
+| Stripe | Payment gateway — tokenisation, authorisation, capture, refunds, payouts |
+| @stripe/stripe-js | Client-side Stripe Elements integration |
+| stripe (Node SDK) | Server-side Stripe API interaction (behind adapter abstraction) |
+
+---
+
+## Identity Verification (KYC)
+
+| Technology | Purpose |
+| ---------- | ------- |
+| Veriff | Third-party identity verification provider (stubbed/mocked for local demo) |
+
+---
+
+## Email
+
+| Technology | Purpose |
+| ---------- | ------- |
+| AWS SES | Transactional and notification email delivery |
+
+---
+
+## Search
+
+Campaign discovery search is served by **PostgreSQL full-text search** over CQRS read models.
+No external search provider is required.
+
+---
+
+## API Documentation
+
+| Technology | Purpose |
+| ---------- | ------- |
+| OpenAPI 3.1 | API specification format |
+| swagger-jsdoc | Generate OpenAPI spec from JSDoc annotations |
+| swagger-ui-express | Serve interactive API docs |
+
+---
+
+## Secrets Management
+
+| Technology | Purpose |
+| ---------- | ------- |
+| AWS Secrets Manager | Secret storage, injection, and rotation (production) |
+| Environment variables | Secret injection for local development |
+
+---
+
+## Object Storage
+
+| Technology | Purpose |
+| ---------- | ------- |
+| AWS S3 | Frontend static assets (CloudFront origin), audit cold storage, KYC document uploads, campaign media |
+
+---
+
+## Linting & Formatting
+
+| Technology | Purpose |
+| ---------- | ------- |
+| ESLint (flat config) | TypeScript linting |
+| Prettier | Code formatting |
+| markdownlint-cli2 | Markdown linting (per L3-007) |
+
+---
+
+## Database & Data Access
+
+| Technology | Purpose |
+| ---------- | ------- |
+| AWS Aurora PostgreSQL | Primary relational database |
+| pg | Database driver (raw SQL queries, no ORM) |
+| DBMate | SQL schema migrations |
+
+---
+
+## Testing
+
+| Technology | Version | Purpose |
+| ---------- | ------- | ------- |
+| Vitest | Latest stable | Unit and integration test runner |
+| SuperTest | Latest stable | HTTP assertion library for API tests |
+| @testing-library/react | Latest stable | React component testing utilities |
+| MSW (Mock Service Worker) | Latest stable | API mocking for frontend tests |
+| Playwright | Latest stable | End-to-end browser tests (root `e2e/` directory) |
+
+### Quality Gates
+
+- Unit test coverage: 90%+ for business logic / domain
+- Integration tests must pass
+- E2E tests must pass
+
+---
+
+## Architecture Pattern
+
+**Hexagonal Architecture** (Ports and Adapters) for clean separation between domain logic and infrastructure concerns.
+
+---
+
+## Compute & Hosting
+
+| Component | Technology | Notes |
+| --------- | ---------- | ----- |
+| Backend API | AWS ECS Fargate (Docker containers) | Behind Application Load Balancer (ALB) |
+| Frontend | AWS CloudFront CDN | S3 origin for static assets |
+| Scheduled Tasks | AWS EventBridge Scheduler | Triggers ECS tasks (e.g., daily historic rates sync at 3 AM UTC) |
+| Container Registry (CI) | GHCR (GitHub Container Registry) | Used during CI builds |
+| Container Registry (Deploy) | AWS ECR | Production container images |
+| Local Development | Docker, Docker Compose | Local environment parity |
+
+---
+
+## Infrastructure as Code
+
+| Technology | Version | Purpose |
+| ---------- | ------- | ------- |
+| Terraform | >= 1.11.0 | Infrastructure provisioning and management |
+| Terraform Cloud | — | Remote state management and execution |
+
+---
+
+## CI/CD
+
+| Component | Technology |
+| --------- | ---------- |
+| Pipeline | GitHub Actions |
+
+### Deployment Strategy
+
+- Automated infrastructure deployment via Terraform
+- Docker image build and push to ECR
+- ECS service updates with rolling deployment
+- React frontend build and S3 upload with CloudFront invalidation
+
+### Environments
+
+- Separate workflows for development and production
+
+---
+
+## Change Log
+
+| Date | Author | Summary |
+| ---- | ------ | ------- |
+| 2026-03-04 | Claude | Initial draft — enumerated all technology choices from architecture prompt |
+| 2026-03-04 | — | Promoted to Review status. Content complete; decisions backfilled into dependent specs. |
+| 2026-03-04 | — | Expanded PostHog role to cover feature flags, product analytics, and web analytics. Added posthog-node for backend feature flag evaluation. Added Feature Flags & Product Operations and Developer Observability sections. |
+| 2026-03-04 | — | Added Stripe as payment gateway (Stripe Elements, stripe Node SDK). |

--- a/specs/tooling/github.md
+++ b/specs/tooling/github.md
@@ -1,0 +1,157 @@
+# GitHub — CLI Reference
+
+> How to manage GitHub resources via the `gh` CLI.
+> The `gh` CLI does not have a dedicated `milestone` subcommand; milestone operations use `gh api` against the GitHub REST API.
+
+## Milestones
+
+### Key concepts
+
+- The REST API identifies milestones by **number** (an integer, assigned sequentially, never reused after deletion).
+- The `gh issue` and `gh pr` commands identify milestones by **name** (a string).
+- These are different identifiers — do not confuse them.
+
+### List milestones
+
+```bash
+# Open milestones (default)
+gh api repos/{owner}/{repo}/milestones
+
+# Closed milestones
+gh api 'repos/{owner}/{repo}/milestones?state=closed'
+
+# All milestones regardless of state
+gh api 'repos/{owner}/{repo}/milestones?state=all'
+
+# Filtered output (number, title, state, description)
+gh api repos/{owner}/{repo}/milestones --jq '.[] | {number, title, state, description}'
+```
+
+### Create a milestone
+
+```bash
+gh api repos/{owner}/{repo}/milestones \
+  -X POST \
+  -f title="Code-Review Plugin v1" \
+  -f description="First release of the code review plugin" \
+  -f state="open"
+```
+
+Optional: add `-f due_on="2026-03-31T00:00:00Z"` for a due date (ISO 8601 format).
+
+Returns the full milestone JSON including the `number` field needed for subsequent operations.
+
+### Get a single milestone
+
+```bash
+gh api repos/{owner}/{repo}/milestones/{number}
+
+# Filtered output
+gh api repos/{owner}/{repo}/milestones/{number} --jq '{number, title, state, open_issues, closed_issues}'
+```
+
+### Update a milestone
+
+```bash
+# Close a milestone
+gh api repos/{owner}/{repo}/milestones/{number} -X PATCH -f state="closed"
+
+# Reopen a milestone
+gh api repos/{owner}/{repo}/milestones/{number} -X PATCH -f state="open"
+
+# Update title and description
+gh api repos/{owner}/{repo}/milestones/{number} -X PATCH \
+  -f title="New Title" \
+  -f description="Updated description"
+
+# Set a due date
+gh api repos/{owner}/{repo}/milestones/{number} -X PATCH \
+  -f due_on="2026-06-30T00:00:00Z"
+```
+
+### Delete a milestone
+
+```bash
+gh api repos/{owner}/{repo}/milestones/{number} -X DELETE
+```
+
+Returns no output (HTTP 204) on success.
+
+### Assign an issue to a milestone
+
+There is no separate "add issue to milestone" endpoint.
+Set the milestone when creating or editing an issue, using the milestone **name** (not number).
+
+```bash
+# At creation time
+gh issue create --title "Create SRE code review" --body "..." --milestone "Code-Review Plugin v1"
+
+# On an existing issue
+gh issue edit 42 --milestone "Code-Review Plugin v1"
+
+# Remove a milestone from an issue
+gh issue edit 42 --remove-milestone
+```
+
+### Assign a PR to a milestone
+
+```bash
+# At creation time
+gh pr create --title "feat: SRE domain" --body "..." --milestone "Code-Review Plugin v1"
+
+# On an existing PR
+gh pr edit 7 --milestone "Code-Review Plugin v1"
+
+# Remove a milestone from a PR
+gh pr edit 7 --remove-milestone
+```
+
+## Issues
+
+Standard `gh issue` subcommands are available.
+See `gh issue --help` for the full reference.
+
+```bash
+# Create an issue linked to a milestone
+gh issue create --title "Title" --body "Body" --milestone "Milestone Name"
+
+# List issues for a milestone
+gh issue list --milestone "Milestone Name"
+
+# Close an issue
+gh issue close 42
+
+# Reopen an issue
+gh issue reopen 42
+
+# Edit an issue
+gh issue edit 42 --title "New title" --body "New body"
+```
+
+## Pull Requests
+
+Standard `gh pr` subcommands are available.
+See `gh pr --help` for the full reference.
+
+```bash
+# Create a PR linked to a milestone
+gh pr create --title "Title" --body "Body" --milestone "Milestone Name"
+
+# View PR checks
+gh pr checks 7
+
+# View PR comments
+gh api repos/{owner}/{repo}/pulls/7/comments
+```
+
+## Quick Reference
+
+| Operation | Command | Identifier |
+|-----------|---------|------------|
+| Create milestone | `gh api repos/{owner}/{repo}/milestones -X POST -f title="..."` | Returns `number` |
+| List milestones | `gh api repos/{owner}/{repo}/milestones` | Query param `?state=open\|closed\|all` |
+| Get milestone | `gh api repos/{owner}/{repo}/milestones/{number}` | Milestone `number` (integer) |
+| Update milestone | `gh api repos/{owner}/{repo}/milestones/{number} -X PATCH` | Milestone `number` (integer) |
+| Delete milestone | `gh api repos/{owner}/{repo}/milestones/{number} -X DELETE` | Milestone `number` (integer) |
+| Assign issue | `gh issue create --milestone "Name"` or `gh issue edit N --milestone "Name"` | Milestone **name** (string) |
+| Assign PR | `gh pr create --milestone "Name"` or `gh pr edit N --milestone "Name"` | Milestone **name** (string) |


### PR DESCRIPTION
## Summary

- Adds the full layered specification hierarchy (L1–L4): product vision, brand & engineering standards, technical architecture (architecture, security, reliability, data management, frontend, audit, markdown, tech stack), and domain workflows (account, campaign, donor, payments, KYC)
- Adds `.gitignore`, logo SVG asset, and comprehensive project README with tech stack, project structure, and getting started guide
- Includes specification index (`specs/README.md`) with dependency graph, agent protocol, and cross-cutting concern index

## Test plan

- [ ] Verify all spec files render correctly on GitHub
- [ ] Verify internal markdown links resolve (README → specs/README.md, specs cross-references)
- [ ] Verify logo.svg renders in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)