### PR TITLE
chore: add Playwright MCP config to repo

### DIFF
--- a/.claude/.mcp.json
+++ b/.claude/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest", "--headless", "--browser", "chromium"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/.mcp.json` with Playwright MCP server config so Claude Code discovers it as project-level config when running from the repo directory
- Required for the autonomous agent Docker containers — after cloning the repo, Claude Code needs this file to connect to the Playwright MCP server for browser automation and screenshots

## Test plan

- [ ] `claude` launched from repo root shows Playwright in MCP servers init
- [ ] Autonomous agent container shows non-empty `mcp_servers` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)