### PR TITLE
fix(autonomous): pipe base64 via stdin to avoid MAX_ARG_STRLEN limit

### DIFF
--- a/autonomous/agent-loop.sh
+++ b/autonomous/agent-loop.sh
@@ -229,13 +229,18 @@ Branch: ${BRANCH}" \
         for img in /screenshots/ISSUE-${ISSUE_NUMBER}-*.png; do
           FNAME=$(basename "$img")
           # Upload to fork repo screenshots branch via contents API (uses fork token)
-          BASE64=$(base64 -w0 "$img" 2>/dev/null || base64 "$img")
-          GH_TOKEN="$GH_TOKEN_FORK" gh api \
+          # Pipe base64 via stdin to jq, then pipe JSON to gh api, to avoid
+          # Linux MAX_ARG_STRLEN (128KB) limit on individual command-line args.
+          (base64 -w0 "$img" 2>/dev/null || base64 "$img") \
+          | tr -d '\n' \
+          | jq -Rs \
+            --arg msg "chore: add screenshot ${FNAME}" \
+            --arg branch "screenshots" \
+            '{message: $msg, content: ., branch: $branch}' \
+          | GH_TOKEN="$GH_TOKEN_FORK" gh api \
             "repos/${FORK_REPO}/contents/screenshots/PR-${PR_NUMBER}/${FNAME}" \
-            -X PUT \
-            -f message="chore: add screenshot ${FNAME}" \
-            -f content="$BASE64" \
-            -f branch="screenshots" 2>/dev/null || true
+            -X PUT --input - \
+          || echo "!!! Failed to upload screenshot: ${FNAME}"
 
           RAW_URL="https://raw.githubusercontent.com/${FORK_REPO}/screenshots/screenshots/PR-${PR_NUMBER}/${FNAME}"
           COMMENT_BODY="${COMMENT_BODY}### ${FNAME}\n![${FNAME}](${RAW_URL})\n\n"


### PR DESCRIPTION
## Summary

- Screenshot uploads for files >98KB were silently failing in the Docker agent
- Root cause: Linux `MAX_ARG_STRLEN` limits individual command-line arguments to 128KB (131,072 bytes). The base64 encoding of screenshots >98KB exceeds this limit when passed via `gh api -f content="$BASE64"`
- Fix: pipe base64 through `stdin → jq → gh api --input -` instead of command-line args
- Also removed `2>/dev/null || true` error suppression so upload failures are visible in logs

## Evidence

Compared local screenshots in `autonomous/logs/3/screenshots/` against files uploaded to the `screenshots` branch on GitHub (`screenshots/PR-27/`):

| File | Base64 Size | vs 131,072 limit | Uploaded? |
|------|-------------|-------------------|-----------|
| TASK-10 | 18,468 | under | Yes |
| TASK-02 | 62,376 | under | Yes |
| TASK-08 | 70,604 | under | Yes |
| TASK-08-mobile | 73,280 | under | Yes |
| TASK-03 | 112,808 | under | Yes |
| TASK-04 | 122,404 | under | Yes |
| **TASK-05** | **132,680** | **over by 1,608** | **No** |
| **TASK-06** | **152,260** | **over** | **No** |
| **TASK-07** | **192,444** | **over** | **No** |
| **TASK-11-mobile** | **229,300** | **over** | **No** |
| **TASK-09** | **238,652** | **over** | **No** |
| **TASK-11-home** | **238,652** | **over** | **No** |

100% correlation — every file under the limit uploaded successfully, every file over failed silently.

## Test plan

- [ ] Verify pipeline produces valid JSON locally: `base64 -i large.png | tr -d '\n' | jq -Rs --arg msg "test" --arg branch "screenshots" '{message: $msg, content: ., branch: $branch}' | jq .message` outputs `"test"`
- [ ] Run the agent on the next issue and verify all screenshots upload regardless of size
- [ ] Check agent logs for any `!!! Failed to upload screenshot` messages (the new error reporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)