### PR TITLE
chore: post-milestone cleanup — learnings.md and schema.sql

### DIFF
--- a/packages/server/db/schema.sql
+++ b/packages/server/db/schema.sql
@@ -1,0 +1,219 @@
+\restrict dbmate
+
+-- Dumped from database version 16.11
+-- Dumped by pg_dump version 18.2
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: campaign_milestones; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.campaign_milestones (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    campaign_id uuid NOT NULL,
+    title text NOT NULL,
+    description text NOT NULL,
+    target_date date NOT NULL,
+    funding_pct integer NOT NULL,
+    verification_criteria text NOT NULL,
+    status text DEFAULT 'Pending'::text NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: campaign_stretch_goals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.campaign_stretch_goals (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    campaign_id uuid NOT NULL,
+    target_usd bigint NOT NULL,
+    description text NOT NULL,
+    deliverables text NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: campaign_team_members; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.campaign_team_members (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    campaign_id uuid NOT NULL,
+    name text NOT NULL,
+    role text NOT NULL,
+    bio text NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: campaign_updates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.campaign_updates (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    campaign_id uuid NOT NULL,
+    body text NOT NULL,
+    posted_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: campaigns; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.campaigns (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    slug text NOT NULL,
+    title text NOT NULL,
+    summary text NOT NULL,
+    description text NOT NULL,
+    alignment_statement text NOT NULL,
+    category text NOT NULL,
+    tags text[] DEFAULT '{}'::text[] NOT NULL,
+    status text NOT NULL,
+    hero_image_url text,
+    min_funding_target_usd bigint NOT NULL,
+    max_funding_cap_usd bigint NOT NULL,
+    current_amount_usd bigint DEFAULT 0 NOT NULL,
+    contributor_count integer DEFAULT 0 NOT NULL,
+    deadline timestamp with time zone,
+    launched_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying NOT NULL
+);
+
+
+--
+-- Name: campaign_milestones campaign_milestones_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_milestones
+    ADD CONSTRAINT campaign_milestones_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: campaign_stretch_goals campaign_stretch_goals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_stretch_goals
+    ADD CONSTRAINT campaign_stretch_goals_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: campaign_team_members campaign_team_members_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_team_members
+    ADD CONSTRAINT campaign_team_members_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: campaign_updates campaign_updates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_updates
+    ADD CONSTRAINT campaign_updates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: campaigns campaigns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaigns
+    ADD CONSTRAINT campaigns_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: campaigns campaigns_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaigns
+    ADD CONSTRAINT campaigns_slug_key UNIQUE (slug);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: campaign_milestones campaign_milestones_campaign_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_milestones
+    ADD CONSTRAINT campaign_milestones_campaign_id_fkey FOREIGN KEY (campaign_id) REFERENCES public.campaigns(id) ON DELETE CASCADE;
+
+
+--
+-- Name: campaign_stretch_goals campaign_stretch_goals_campaign_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_stretch_goals
+    ADD CONSTRAINT campaign_stretch_goals_campaign_id_fkey FOREIGN KEY (campaign_id) REFERENCES public.campaigns(id) ON DELETE CASCADE;
+
+
+--
+-- Name: campaign_team_members campaign_team_members_campaign_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_team_members
+    ADD CONSTRAINT campaign_team_members_campaign_id_fkey FOREIGN KEY (campaign_id) REFERENCES public.campaigns(id) ON DELETE CASCADE;
+
+
+--
+-- Name: campaign_updates campaign_updates_campaign_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_updates
+    ADD CONSTRAINT campaign_updates_campaign_id_fkey FOREIGN KEY (campaign_id) REFERENCES public.campaigns(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict dbmate
+
+
+--
+-- Dbmate schema migrations
+--
+
+INSERT INTO public.schema_migrations (version) VALUES
+    ('20260309000001'),
+    ('20260309000002'),
+    ('20260309000003'),
+    ('20260309000004'),
+    ('20260309000005'),
+    ('20260309000006');

--- a/specs/learnings.md
+++ b/specs/learnings.md
@@ -2,86 +2,71 @@
 
 Tips and gotchas discovered by previous agents. Read this before starting work.
 
-## Issue #53: @mmf/shared package was not pre-created by issue #50
+## Tooling & Config
 
-- TASK-05 says to import from `@mmf/shared` and notes it as a prerequisite from issue #50, but `packages/shared` did not exist when the task ran.
-- `packages/client/package.json` already listed `"@mmf/shared": "*"` as a dependency (set in TASK-02), so the workspace was expecting it.
-- Resolution: created a minimal `packages/shared/package.json` + `packages/shared/src/index.ts` exporting the five Campaign types. Used `"exports": { ".": "./src/index.ts" }` so bundler-mode TypeScript resolves the types directly from source without needing a separate compile step.
-- Re-exporting the types from `packages/client/src/api/campaigns.ts` (`export type { ... }`) preserves backward compatibility for all components that import types from that module.
+### Prettier and markdownlint MD049 conflict
 
-## Issue #1: Frontend scaffold (Issue #2) was missing
-
-- The `plan/ready/tasks.md` for Issue #3 starts at TASK-01 (Button), but the frontend scaffold from Issue #2 had not been completed.
-- There was no `src/` directory, `package.json`, or any project files.
-- Resolution: Created the full scaffold as preparation before TASK-01:
-  - `package.json` with React 19, Vite, Tailwind v4, React Router v7, TypeScript (strict)
-  - `src/tokens.css` with all Tier 1 and Tier 2 CSS custom properties from L2-001
-  - `src/index.css` with Tailwind v4 `@import "tailwindcss"`, font imports, base styles
-  - Self-hosted fonts via `@fontsource/bebas-neue`, `@fontsource/dm-sans`, `@fontsource/space-mono` npm packages (no external CDN)
-  - `vite.config.ts`, `tsconfig*.json`, `index.html`, `src/main.tsx`, `src/App.tsx`
-- The `@fontsource` npm approach satisfies self-hosted font requirement (no Google CDN at runtime).
-
-## Issue #3: Prettier and markdownlint MD049 conflict
-
-- Prettier (default) normalises Markdown emphasis to `_text_` (underscores), but markdownlint MD049 (configured to "asterisk") requires `*text*`.
+- Prettier normalises Markdown emphasis to `_text_` (underscores), but markdownlint MD049 (configured to "asterisk") requires `*text*`.
 - Running `prettier --write .` on `.md` files after fixing MD049 violations will silently revert them.
-- Resolution: add `**/*.md` to `.prettierignore` so Prettier never touches Markdown files. Markdownlint is the single source of truth for `.md` style.
+- Resolution: `**/*.md` is in `.prettierignore` so Prettier never touches Markdown files. Markdownlint is the single source of truth for `.md` style.
 
-## Issue #4: Vitest v4 requires `defineConfig` from `vitest/config`
+### Vitest v4 requires `defineConfig` from `vitest/config`
 
 - Using `/// <reference types="vitest" />` alone with `defineConfig` from `vite` causes TS2769 in `vite.config.ts` ("test does not exist in type 'UserConfigExport'").
 - Resolution: Import `defineConfig` from `vitest/config` instead of `vite`. This pulls in Vitest's module augmentation that adds `test` to Vite's `UserConfig` interface.
 
-## Issue #5: @testing-library/jest-dom v6 with Vitest requires `/vitest` import
+### @testing-library/jest-dom v6 with Vitest requires `/vitest` import
 
 - Importing `@testing-library/jest-dom` in a Vitest setup file causes `ReferenceError: expect is not defined` because the default entry tries to extend Jest's global `expect`.
 - Resolution: Use `import '@testing-library/jest-dom/vitest'` instead, which uses Vitest's `expect` API. This entry point is available in v6+.
 
-## Issue #41: Vitest in server/ picks up root vite.config.ts
+### Root vitest exclude must cover `packages/**`
 
-- Running `vitest run` from `server/` picks up the root `vite.config.ts` which sets `environment: 'jsdom'` and `setupFiles: ['src/test/setup.ts']` — causing failures in the server test suite.
-- Resolution: Create `server/vitest.config.ts` with `environment: 'node'` to override the root config.
+- The root `vite.config.ts` `test.exclude` must include `packages/**` to prevent the frontend test runner from finding workspace package tests (e.g. `packages/server/src/__tests__/campaigns.test.ts`).
 
-## Issue #41: Mocking pg QueryResult in Vitest
+## Server Patterns
 
-- Casting `{ rows: [], rowCount: 0 }` as `QueryResult` causes TS2352 because the partial object doesn't overlap enough with the full type.
-- Resolution: Remove the cast entirely — `mockResolvedValueOnce` accepts `unknown`, so no cast is needed. The mock return value does not need to satisfy the full `QueryResult` interface.
+### Express factory app pattern
 
-## Issue #2: Vite rejects `<noscript>` inside `<head>`
+- The app is built as a factory function `createApp(pool: Pool): Express` that accepts the database pool via dependency injection. This pattern is required so tests can pass a mock pool without side effects from real DB connections or port binding.
 
-- Placing `<noscript>` in the `<head>` of `index.html` causes a parse5 build error: "disallowed-content-in-noscript-in-head".
-- Resolution: Move `<noscript>` to `<body>` instead.
+### NodeNext requires `.js` extensions on TypeScript imports
 
-## Issue #54: Root vitest exclude must cover packages/**
-
-- Moving server files from `server/` to `packages/server/` causes root vitest to pick up server tests (e.g. `packages/server/src/__tests__/campaigns.test.ts`) because `vite.config.ts` only excluded `server/**`.
-- The root `vite.config.ts` `test.exclude` must include `packages/**` to prevent the frontend test runner from finding workspace package tests.
-- Resolution: add `'packages/**'` to the `exclude` array in `vite.config.ts`.
-
-## Issues #40–#43: Public Campaign Pages — Tooling Notes
-
-- The `server/` directory is a **separate Node.js project** with its own `package.json`, `tsconfig.json`, and `vitest.config.ts`. It is entirely independent of the root frontend build and test commands; run `npm test` inside `server/` to execute server-side tests.
 - The server `tsconfig.json` uses `"module": "NodeNext"` and `"moduleResolution": "NodeNext"`. This requires **`.js` file extensions on all TypeScript import paths**, even though the actual source files are `.ts` (e.g. `import { createApp } from '../app.js'`). Omitting the extension causes a runtime `ERR_MODULE_NOT_FOUND`.
-- The server `vitest.config.ts` only needs `environment: 'node'`; no special ESM transforms are required because `server/package.json` sets `"type": "module"`, which makes Node treat all `.js` output as ESM.
-- **Express 5 + SuperTest testability**: the app is built as a factory function `createApp(pool: Pool): Express` that accepts the database pool via dependency injection. This pattern is required so tests can pass a mock pool without side effects from real DB connections or port binding.
-- The `src/api/<domain>.ts` layer falls back to inline mock data when the API returns a non-OK response or is unreachable. This makes the frontend fully functional during local development even when the Express server is not running.
 
-## Issues #65–#66: Port mismatch between Vite proxy and server
+### Mocking pg QueryResult in Vitest
 
-- Vite's `server.proxy` target port must exactly match the `PORT` value in `packages/server/.env`. During issues #65/#66 these drifted (proxy pointed to 3001, server listened on 3000), causing all API calls to silently fail.
-- Resolution: always verify both values are identical before starting development. Prefer committing a `.env.example` with the canonical port so developers and CI stay in sync.
+- Casting `{ rows: [], rowCount: 0 }` as `QueryResult` causes TS2352. Resolution: remove the cast — `mockResolvedValueOnce` accepts `unknown`, so no cast is needed.
 
-## Issues #65–#66: camelCase transformation for API responses
+### Server vitest config overrides root
+
+- Running `vitest run` from `packages/server/` picks up the root `vite.config.ts` which sets `environment: 'jsdom'`. Resolution: `packages/server/vitest.config.ts` sets `environment: 'node'` to override.
+
+## Client-Server Integration Patterns
+
+### Port mismatch between Vite proxy and server
+
+- Vite's `server.proxy` target port must exactly match the `PORT` value in `packages/server/.env`. These can drift silently, causing all API calls to fail.
+- Always verify both values are identical. A `.env.example` with the canonical port keeps developers and CI in sync.
+
+### camelCase transformation for API responses
 
 - DB columns use `snake_case` (e.g. `min_funding_target_usd`). All API JSON responses must use `camelCase`. The server aliases column names directly in SQL `SELECT` clauses (e.g. `min_funding_target_usd AS "minFundingTargetUsd"`).
-- Shared Zod schemas in `@mmf/shared` must use camelCase field names to match the API responses; any `snake_case` field name in a Zod schema will fail to parse real API data at runtime.
+- Shared Zod schemas in `@mmf/shared` must use camelCase field names to match the API responses.
 
-## Issues #65–#66: Nested entity queries for campaign detail
+### Nested entity queries for campaign detail
 
-- The campaign detail endpoint (`GET /api/campaigns/:slug`) fetches milestones, stretch goals, team members, and campaign updates via separate SQL queries, then assembles them into a single `CampaignDetail` object in application code.
-- This avoids complex multi-table JOINs and keeps each query simple and independently testable. Future contributors should follow the same pattern rather than adding large JOIN queries.
+- The campaign detail endpoint (`GET /api/campaigns/:slug`) fetches milestones, stretch goals, team members, and updates via separate SQL queries, then assembles them in application code.
+- This avoids complex multi-table JOINs and keeps each query simple and independently testable.
 
-## Issues #65–#66: Mock data removal enables reliable error-state testing
+### Mock data removal enables reliable error-state testing
 
-- The client API layer previously caught all fetch errors and returned inline mock data as a fallback. While convenient for local development, this masked real server errors and made E2E tests unable to verify error states.
-- Resolution: remove the catch-block fallbacks and re-throw errors instead. The UI renders loading/error states using React state, and E2E tests can now reliably detect when the server returns an error.
+- The client API layer previously caught all fetch errors and returned inline mock data. This masked real server errors and made E2E tests unable to verify error states.
+- Resolution: re-throw errors instead. The UI renders loading/error states using React state.
+
+## Monorepo Structure
+
+### @mmf/shared package
+
+- `packages/shared/src/index.ts` exports the shared Campaign types. Uses `"exports": { ".": "./src/index.ts" }` so bundler-mode TypeScript resolves types directly from source without a compile step.
+- Re-exporting types from `packages/client/src/api/campaigns.ts` preserves backward compatibility for components importing from that module.


### PR DESCRIPTION
## Summary

- **Reorganised `specs/learnings.md`** by category (Tooling & Config, Server Patterns, Client-Server Integration, Monorepo Structure) instead of by issue number for better scannability
- **Committed `packages/server/db/schema.sql`** — dbmate schema dump that acts as a reviewable schema snapshot (like a lockfile)
- **Deleted stale artifacts** — completed `plan/client-server-integration/` directory and leftover `docker-*.log` files

### Learnings.md changes
- Updated path references from `server/` to `packages/server/`
- Removed one-time scaffold entries (Issues #1, #2) that won't recur
- Consolidated four separate #65-66 entries into a single "Client-Server Integration Patterns" section
- All remaining entries verified as still valid and active

## Test plan

- [x] `markdownlint` passes on updated learnings.md
- [x] No root-level `*.log` files remain
- [x] `plan/client-server-integration/` deleted
- [x] `schema.sql` tracked in git

🤖 Generated with [Claude Code](https://claude.com/claude-code)
