### PR TITLE
chore: update Claude settings and plan spec reference

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,7 +41,9 @@
       "Bash(node:*)",
       "Bash(eslint:*)",
       "Bash(prettier:*)",
-      "Bash(tsc:*)"
+      "Bash(tsc:*)",
+      "Bash(./scripts/:*)",
+      "mcp__playwright__*"
     ],
     "deny": ["Bash(git branch -D:*)", "Bash(gh pr merge:*)"]
   },

--- a/scripts/PLAN.md
+++ b/scripts/PLAN.md
@@ -26,6 +26,7 @@ Milestone          → The deliverable (what stakeholders care about)
 Read the user's request. Then read relevant specifications:
 
 - `specs/README.md` — spec index
+- `specs/tooling/github.md` - how to create milestones correctly with GitHub's API and CLI
 - Any domain specs referenced by the request
 
 ### Step 2: Socratic Elicitation


### PR DESCRIPTION
## Summary
- Add `./scripts/` and `mcp__playwright__*` to Claude Code allow-list
- Reference GitHub tooling spec in `scripts/PLAN.md`

## Test plan
- [x] CI passes (pre-push hook ran all checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
