### PR TITLE
fix: prevent finalize-pr state from being skipped

### DIFF
--- a/autonomous/agent-loop.sh
+++ b/autonomous/agent-loop.sh
@@ -148,7 +148,7 @@ determine_state() {
   elif [ -f "plan/ready/tasks.md" ]; then
     if grep -q '^\- \[ \]' "plan/ready/tasks.md"; then
       echo "execute-tasks"
-    elif [ -f "plan/.pr-number" ]; then
+    elif [ -f "plan/.finalized" ]; then
       echo "await-ci"
     else
       echo "finalize-pr"
@@ -362,6 +362,7 @@ Branch: ${BRANCH}"
 
     # Persist PR number for await-ci state (do NOT archive plan yet — needed for remediation)
     echo "$PR_NUMBER" > plan/.pr-number
+    touch plan/.finalized
     clear_state
     echo ">>> PR #${PR_NUMBER} finalized for issue #${ISSUE_NUMBER}, transitioning to await-ci"
     exit 1  # iterate again into await-ci


### PR DESCRIPTION
## Summary

- `determine_state()` used `plan/.pr-number` to decide between `finalize-pr` and `await-ci` states
- But `.pr-number` is written during `create-tasks` (when the draft PR is created), so when all tasks completed, the state machine jumped straight to `await-ci` — skipping `finalize-pr` entirely
- This left PR #86 stuck in draft state despite CI passing
- Fix: use a separate `plan/.finalized` marker file that is only written after `finalize-pr` completes

## Test plan

- [ ] Run `implement-milestone.sh` and verify PR transitions from draft to ready after all tasks complete
- [ ] Verify `finalize-pr` state is entered after all tasks are done (check logs for `State: finalize-pr`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)