### PR TITLE
feat(autonomous): add E2E test authoring to agent workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Run DB migrations
+        if: github.event_name == 'push' || github.event.pull_request.draft == false
         env:
           DATABASE_URL: postgres://mmf:mmf@localhost:5432/mmf_test?sslmode=disable
         run: >
@@ -68,9 +69,11 @@ jobs:
           ghcr.io/amacneil/dbmate up
 
       - name: Install Playwright browsers
+        if: github.event_name == 'push' || github.event.pull_request.draft == false
         run: npx playwright install --with-deps chromium
 
       - name: Start server
+        if: github.event_name == 'push' || github.event.pull_request.draft == false
         env:
           DATABASE_URL: postgres://mmf:mmf@localhost:5432/mmf_test?sslmode=disable
           JWT_SECRET: test-jwt-secret
@@ -78,6 +81,7 @@ jobs:
         run: npm run dev:server &
 
       - name: E2E tests
+        if: github.event_name == 'push' || github.event.pull_request.draft == false
         env:
           DATABASE_URL: postgres://mmf:mmf@localhost:5432/mmf_test?sslmode=disable
         run: npm run test:e2e

--- a/autonomous/prompts/create-brief.md
+++ b/autonomous/prompts/create-brief.md
@@ -58,6 +58,7 @@ How to verify the implementation is correct:
 - Build: `npm run build` succeeds
 - Visual: what to check in the browser at `http://localhost:5173`
 - Tests: any specific test commands
+- E2E: user flows that should have Playwright E2E tests (e.g. "navigate to /campaigns, click a card, see detail page")
 ```
 
 ### Step 3: Self-Review

--- a/autonomous/prompts/create-tasks.md
+++ b/autonomous/prompts/create-tasks.md
@@ -52,6 +52,18 @@ Brief: plan/ready/brief.md
 - **Verification**: Every task must have a concrete verification step (build, visual check, test)
 - **No gaps**: The complete checklist should fully implement the brief — nothing missing
 - **Human-only actions**: Do NOT create tasks for closing issues, closing milestones, or merging PRs. These are handled by humans outside the agent workflow. If the issue's only deliverables are human actions, create a single task that comments on the issue listing the actions the human needs to perform.
+- **E2E tests**: If the brief's Verification section includes E2E flows, include a dedicated E2E test task near the end of the checklist (before any final cleanup task). Template:
+
+  ```text
+  - [ ] TASK-NN: Write E2E tests
+    - **Goal**: Create Playwright E2E tests covering the user flows described in the brief
+    - **Details**: Create or update files in `e2e/`. Follow patterns in existing tests (`e2e/auth.spec.ts`, `e2e/campaigns.spec.ts`). Use Playwright Test API. Tests must pass against the running local stack.
+    - **Files**: `e2e/<feature>.spec.ts`
+    - **Verify**: Run `npm run test:e2e` — all tests pass (existing + new)
+    - **Brief ref**: Verification section
+  ```
+
+  For backend-only issues with no UI flows, omit this task.
 
 ## Output Format
 

--- a/autonomous/prompts/execute-tasks.md
+++ b/autonomous/prompts/execute-tasks.md
@@ -43,11 +43,24 @@ Follow project standards:
 - **Accessibility**: Semantic HTML, focus-visible states, `prefers-reduced-motion` support
 - **File structure**: Follow component architecture from specs
 
+### E2E Test Writing Guide
+
+When the current task is an E2E test task, follow these guidelines:
+
+- **Read first**: Read `e2e/auth.spec.ts` and `e2e/campaigns.spec.ts` as canonical examples before writing any E2E tests
+- **Structure**: Import from `@playwright/test`, use `test.describe` blocks, name files `e2e/<feature>.spec.ts`
+- **Locators**: Use `getByRole`, `getByLabel`, `getByText` (accessibility-first, matching existing patterns)
+- **Coverage**: Include both happy-path and error-state tests. Use `page.route()` for error simulation
+- **Authentication**: If tests need login, define a local `login()` helper following the pattern in `auth.spec.ts`
+- **Do NOT use Playwright MCP** for E2E test authoring — write standard Playwright Test code
+
 ### Step 4: Verify
 
 Run `./scripts/ci-check.sh` before committing. Every check must pass.
 
 If any check fails, fix the issue and re-run until all pass.
+
+If the task created or modified files in `e2e/`, also run `npm run test:e2e` to verify E2E tests pass.
 
 **Visual verification**: If the task involves UI changes:
 

--- a/autonomous/prompts/finalize-pr.md
+++ b/autonomous/prompts/finalize-pr.md
@@ -23,6 +23,8 @@ If any check fails, fix the issue, commit the fix, and re-run until all pass.
 
 Verify all tasks in `plan/ready/tasks.md` are checked `[x]`.
 
+If the brief's Verification section mentions E2E flows, check that `git diff main...HEAD --name-only` includes at least one `e2e/*.spec.ts` file. If missing, add a note to the PR description: "Note: E2E tests were expected but not found."
+
 ### Step 2: Prepare PR Description
 
 Read `plan/ready/brief.md` and `plan/ready/tasks.md` to create a PR summary:

--- a/autonomous/prompts/remediate-ci.md
+++ b/autonomous/prompts/remediate-ci.md
@@ -71,6 +71,7 @@ Read the CI failure logs provided below to identify the root cause. Common failu
 - **Format errors**: Prettier violations — run `npm run format`
 - **Test failures**: Failing tests — fix the code or tests
 - **Build errors**: Build step failures — fix the build issue
+- **E2E test failures**: Playwright tests failed — read the output to identify which test and why. Common causes: selector changes (UI updated but tests reference old selectors), timing issues (add proper waits), or missing test data. Fix the E2E test or the underlying code.
 
 #### Step 2: Reproduce locally
 


### PR DESCRIPTION
## Summary

Adds E2E test authoring to the autonomous agent workflow and makes CI skip E2E steps on draft PRs. Draft PRs still get fast feedback (type-check, lint, build, unit tests) while E2E only runs on non-draft PRs and pushes to main.

## Changes

- **CI workflow**: Gate 4 E2E-related steps (DB migrations, Playwright install, server start, E2E tests) behind `if: github.event_name == 'push' || github.event.pull_request.draft == false`
- **create-brief.md**: Add E2E bullet to the Verification template so briefs describe expected E2E coverage
- **create-tasks.md**: Add guideline requiring a dedicated E2E test task for UI features with E2E flows in the brief
- **execute-tasks.md**: Add E2E Test Writing Guide section (read examples first, use accessible locators, include error states, no Playwright MCP) and verify step for E2E files
- **remediate-ci.md**: Add E2E test failures to the common CI failures list
- **finalize-pr.md**: Add soft-check that `e2e/*.spec.ts` files exist when the brief expects E2E coverage

## Test plan

- [ ] Create a draft PR and confirm E2E steps show as skipped in CI
- [ ] Mark it ready and confirm E2E steps run
- [ ] Review each prompt diff for clarity and consistency with existing voice/format
- [ ] Run the agent on a test issue with UI scope and verify it creates an E2E test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
