### PR TITLE
fix: correct script glob pattern in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,7 +42,7 @@
       "Bash(eslint:*)",
       "Bash(prettier:*)",
       "Bash(tsc:*)",
-      "Bash(./scripts/:*)",
+      "Bash(./scripts/*)",
       "mcp__playwright__*"
     ],
     "deny": ["Bash(git branch -D:*)", "Bash(gh pr merge:*)"]


### PR DESCRIPTION
## Summary

Fix the script auto-approve glob pattern in `.claude/settings.json`. The pattern `Bash(./scripts/:*)` had a stray colon that prevented `./scripts/*` commands from matching, requiring manual approval each time.

## Test plan

- [ ] Run `./scripts/ci-check.sh` and confirm it auto-approves without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
