### PR TITLE
chore: add VS Code Dev Container for cross-platform development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:22
+
+# Install PostgreSQL client for psql debugging access
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dbmate for database migrations
+ARG DBMATE_VERSION=2.24.2
+RUN curl -fsSL -o /usr/local/bin/dbmate \
+    "https://github.com/amacneil/dbmate/releases/download/v${DBMATE_VERSION}/dbmate-linux-amd64" \
+    && chmod +x /usr/local/bin/dbmate

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "Mars Mission Fund",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/mars-mission-fund",
+  "forwardPorts": [5173, 3001, 5432],
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "postStartCommand": "dbmate --url \"${DATABASE_URL}\" --migrations-dir packages/server/db/migrations up",
+  "remoteUser": "node",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "ms-playwright.playwright",
+        "ms-azuretools.vscode-docker"
+      ],
+      "settings": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "explicit"
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspaces/mars-mission-fund:cached
+    environment:
+      DATABASE_URL: postgresql://mmf:mmf@db:5432/mmf?sslmode=disable
+      JWT_SECRET: local-dev-jwt-secret
+      PORT: '3001'
+      NODE_ENV: development
+    command: sleep infinity
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: mmf
+      POSTGRES_PASSWORD: mmf
+      POSTGRES_DB: mmf
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U mmf']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm ci
+npx playwright install --with-deps chromium
+npm run prepare

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,16 @@ npm run dev                     # Frontend dev server only (port 5173)
 npm run dev:server              # Backend dev server only (port 3001)
 ```
 
+### Dev Container (recommended on Windows)
+
+A VS Code Dev Container provides a full Linux dev environment via Docker Desktop + WSL2.
+
+1. Open the repo in VS Code → Command Palette → **"Dev Containers: Reopen in Container"**
+1. PostgreSQL starts automatically as a sidecar; migrations run on each container start
+1. Use `npm run dev` and `npm run dev:server` directly — no `run-local.sh` needed
+1. `scripts/ci-check.sh` and `npm run test:e2e` work as-is inside the container
+1. Debug PostgreSQL with `psql -h db -U mmf -d mmf`
+
 ### CI Checks (run before pushing)
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a Docker Compose-based Dev Container (`.devcontainer/`) with a Node 22 app container and PostgreSQL 16-alpine sidecar
- Installs dbmate as a native binary and postgresql-client for debugging — no Docker-in-Docker needed
- Lifecycle hooks: `npm ci` + Playwright install on create, idempotent migrations on every start
- Documents Dev Container usage in CLAUDE.md

## Design decisions

- **Sidecar PostgreSQL** instead of Docker-in-Docker — simpler and more reliable
- **Separate compose file** from `docker-compose.dev.yml` — existing non-devcontainer workflow is untouched
- **dbmate as binary** instead of via Docker — eliminates need for Docker socket inside container

## Test plan

- [x] Open repo in VS Code → "Dev Containers: Reopen in Container" — container builds successfully
- [x] `psql -h db -U mmf -d mmf -c '\dt'` shows migrated tables
- [ ] `npm run dev:server` + `npm run dev` starts both servers; app loads at localhost:5173
- [x] `npm run test` passes
- [x] `scripts/ci-check.sh` passes
- [ ] `npm run test:e2e` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)