### PR TITLE
feat: enable E2E tests in autonomous agent Docker setup

### DIFF
--- a/autonomous/entrypoint.sh
+++ b/autonomous/entrypoint.sh
@@ -85,6 +85,10 @@ if [ -f package.json ]; then
   npm ci
 fi
 
+# ── Database env for E2E tests ─────────────────────────────
+export DATABASE_URL="postgresql://mmf:mmf@db:5432/mmf?sslmode=disable"
+export JWT_SECRET="test-jwt-secret-for-agent"
+
 # ── Run agent loop for this single issue ─────────────────────
 echo ""
 echo "=========================================="

--- a/autonomous/prompts/execute-tasks.md
+++ b/autonomous/prompts/execute-tasks.md
@@ -54,13 +54,29 @@ When the current task is an E2E test task, follow these guidelines:
 - **Authentication**: If tests need login, define a local `login()` helper following the pattern in `auth.spec.ts`
 - **Do NOT use Playwright MCP** for E2E test authoring — write standard Playwright Test code
 
+### E2E Test Execution
+
+The database is running at `db:5432` with `DATABASE_URL` and `JWT_SECRET` set.
+
+To run E2E tests, use the helper script which handles the full lifecycle (dbmate up → start backend → run Playwright → stop backend → dbmate down):
+
+```bash
+./scripts/run-e2e.sh
+```
+
+To run a specific test file:
+
+```bash
+./scripts/run-e2e.sh e2e/auth.spec.ts
+```
+
 ### Step 4: Verify
 
 Run `./scripts/ci-check.sh` before committing. Every check must pass.
 
 If any check fails, fix the issue and re-run until all pass.
 
-If the task created or modified files in `e2e/`, also run `npm run test:e2e` to verify E2E tests pass.
+If the task created or modified files in `e2e/`, also run `./scripts/run-e2e.sh` to verify E2E tests pass.
 
 **Visual verification**: If the task involves UI changes:
 

--- a/autonomous/prompts/remediate-ci.md
+++ b/autonomous/prompts/remediate-ci.md
@@ -77,6 +77,12 @@ Read the CI failure logs provided below to identify the root cause. Common failu
 
 Run `./scripts/ci-check.sh` to reproduce the failure locally. This runs the same checks as CI.
 
+To reproduce E2E test failures:
+
+```bash
+./scripts/run-e2e.sh
+```
+
 #### Step 3: Fix the issue
 
 Make the minimum changes necessary to fix the CI failure.

--- a/autonomous/prompts/resolve-conflicts.md
+++ b/autonomous/prompts/resolve-conflicts.md
@@ -6,29 +6,9 @@ After the skill completes and the branch is pushed, also run E2E tests to verify
 
 ## E2E Verification
 
-The database is already running (PostgreSQL at `db:5432`) with `DATABASE_URL` and `JWT_SECRET` set in the environment.
-
-1. Start the backend server in the background:
-
 ```bash
 cd /workspace/repo
-npm run dev:server &
-SERVER_PID=$!
-sleep 5
+./scripts/run-e2e.sh
 ```
 
-1. Run E2E tests:
-
-```bash
-npx playwright test
-```
-
-1. Stop the backend:
-
-```bash
-kill $SERVER_PID 2>/dev/null || true
-```
-
-If E2E tests fail, investigate the failures and fix them. After fixing, re-run `./scripts/ci-check.sh` to confirm CI still passes, then push the fixes and re-run E2E tests.
-
-**Important:** Do not skip E2E failures — they must pass before the task is complete.
+If E2E tests fail, investigate and fix. Re-run `./scripts/ci-check.sh` then `./scripts/run-e2e.sh`.

--- a/autonomous/resolve-conflicts-entrypoint.sh
+++ b/autonomous/resolve-conflicts-entrypoint.sh
@@ -46,9 +46,6 @@ fi
 export DATABASE_URL="postgresql://mmf:mmf@db:5432/mmf?sslmode=disable"
 export JWT_SECRET="test-jwt-secret-for-conflict-resolution"
 
-echo ">>> Running database migrations"
-dbmate -d packages/server/db/migrations -s packages/server/db/schema.sql up
-
 # ── Check PR status ─────────────────────────────────────────
 echo ">>> Checking PR #${PR_NUMBER} status"
 PR_STATUS=$(GH_TOKEN="$GH_TOKEN_UPSTREAM" gh pr view "$PR_NUMBER" \

--- a/scripts/docker-e2e-entrypoint.sh
+++ b/scripts/docker-e2e-entrypoint.sh
@@ -27,23 +27,6 @@ echo "=== All CI checks passed ==="
 # --- E2E tests (DB required) ---
 
 echo "=== E2E tests ==="
-
-# Run database migrations
-echo "Running database migrations…"
-dbmate -d ./packages/server/db/migrations -s ./packages/server/db/schema.sql up
-echo "Migrations complete."
-
-# Start the backend dev server in the background
-npm run dev:server &
-
-# Wait for backend to accept connections
-echo "Waiting for backend…"
-until curl -sf http://localhost:3001/v1/campaigns > /dev/null 2>&1; do
-  sleep 1
-done
-echo "Backend is ready."
-
-# Run Playwright e2e tests (Playwright starts the Vite dev server itself)
-npx playwright test
+./scripts/run-e2e.sh
 
 echo "=== All checks passed ==="

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run E2E tests with clean database state.
+# Requires: DATABASE_URL, JWT_SECRET in environment; dbmate installed.
+# Usage: ./scripts/run-e2e.sh [playwright-args...]
+
+SERVER_PID=""
+
+cleanup() {
+  echo ">>> Stopping backend..."
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+  echo ">>> Tearing down database..."
+  dbmate -d packages/server/db/migrations -s packages/server/db/schema.sql down
+  echo ">>> E2E teardown complete."
+}
+trap cleanup EXIT
+
+echo ">>> Migrating database..."
+dbmate -d packages/server/db/migrations -s packages/server/db/schema.sql up
+
+npm run dev:server &
+SERVER_PID=$!
+
+echo ">>> Waiting for backend..."
+until curl -sf http://localhost:3001/v1/campaigns > /dev/null 2>&1; do
+  sleep 1
+done
+echo ">>> Backend is ready."
+
+npx playwright test "$@"


### PR DESCRIPTION
Closes #133 (sub-task of #131, item 8: E2E tests can't run in the container)

## Summary

- Add shared `scripts/run-e2e.sh` that handles the full E2E lifecycle: dbmate up, start backend, run Playwright, stop backend, dbmate down
- Export `DATABASE_URL` and `JWT_SECRET` in agent entrypoint so the autonomous agent can run E2E tests
- Refactor `docker-e2e-entrypoint.sh` and `resolve-conflicts-entrypoint.sh` to use the shared script
- Update agent prompts (execute-tasks, remediate-ci, resolve-conflicts) to reference `./scripts/run-e2e.sh`

## Test plan

- [ ] `./scripts/e2e-check-docker.sh` passes with refactored `docker-e2e-entrypoint.sh`
- [ ] `cd autonomous && docker compose build` succeeds
- [ ] Agent run against a test issue that includes E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)