### PR TITLE
fix: enforce full CI checks, prevent stub files, add lsof

### DIFF
--- a/autonomous/Dockerfile
+++ b/autonomous/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     jq \
+    lsof \
     sudo \
   && rm -rf /var/lib/apt/lists/*
 

--- a/autonomous/prompts/create-tasks.md
+++ b/autonomous/prompts/create-tasks.md
@@ -46,6 +46,7 @@ Brief: plan/ready/brief.md
 ### Guidelines
 
 - **Order matters**: Tasks must be ordered so each can build on the previous
+- **Co-locate routes and pages**: If a task adds a route that imports a page component, that same task must create the page component. Do NOT create placeholder/stub files for components that will be implemented in later tasks — stubs cause lint errors (`no-unused-vars`) and thrashing. Use `React.lazy(() => import(...))` with a loading fallback if a route must exist before the page is ready.
 - **First task**: Usually project setup, dependencies, or configuration
 - **Last task**: Usually integration, final verification, or cleanup
 - **Granularity**: Prefer more smaller tasks over fewer large ones

--- a/autonomous/prompts/execute-tasks.md
+++ b/autonomous/prompts/execute-tasks.md
@@ -75,7 +75,9 @@ To run a specific test file:
 
 ### Step 4: Verify
 
-Run `./scripts/ci-check.sh` before committing. Every check must pass.
+Run `./scripts/ci-check.sh` before committing — this includes type-checking, linting, **Prettier formatting**, and tests. Every check must pass.
+
+Do NOT cherry-pick individual checks (e.g. running only `tsc` or `eslint`). Always run the full `./scripts/ci-check.sh` script so formatting and other issues are caught immediately rather than accumulating across tasks.
 
 If any check fails, fix the issue and re-run until all pass.
 


### PR DESCRIPTION
## Summary

- Require agents to run full `ci-check.sh` instead of cherry-picking individual checks, so Prettier formatting is caught immediately (#2)
- Add task planning guidance to co-locate route and page creation, preventing stub files that trigger lint thrashing (#3)
- Install `lsof` in the Dockerfile so agents can manage background processes (#9)

Addresses items #2, #3, #9 from #131.

Closes #137

## Test plan

- [x] `npm run lint:md` passes
- [x] All CI checks pass (pre-push hook ran successfully)
- [ ] Review prompt and Dockerfile changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
