### PR TITLE
fix: handle all-tasks-complete in agent-loop stuck detection

### DIFF
--- a/autonomous/agent-loop.sh
+++ b/autonomous/agent-loop.sh
@@ -303,7 +303,14 @@ Upstream repo: ${UPSTREAM_REPO}"
     AFTER=${AFTER:-0}
     echo ">>> Tasks remaining: ${BEFORE} → ${AFTER}"
 
-    # Stuck detection
+    # All tasks complete — transition to finalize-pr
+    if [ "$AFTER" -eq 0 ]; then
+      echo ">>> All tasks complete"
+      clear_state
+      exit 1
+    fi
+
+    # Stuck detection — no progress and tasks remain
     if [ "$BEFORE" -eq "$AFTER" ]; then
       echo "!!! No progress made — agent may be stuck"
       clear_state


### PR DESCRIPTION
## Summary

- Add early check for `AFTER == 0` in `execute-tasks` state before stuck detection
- When all tasks are complete, transition to `finalize-pr` (exit 1) instead of reporting stuck (exit 2)
- Prevents wasting a full Claude session (~$0.94) when the agent detects no unchecked tasks remain

Addresses item #5 from #131. This is the final remaining item — all 9 issues are now addressed.

Closes #139

## Test plan

- [x] All CI checks pass (pre-push hook ran successfully)
- [ ] Review logic change in `agent-loop.sh` lines 307-317

🤖 Generated with [Claude Code](https://claude.com/claude-code)
