### PR TITLE
fix: pin @playwright/test to 1.58.2 to match Docker base image

### DIFF
--- a/autonomous/Dockerfile
+++ b/autonomous/Dockerfile
@@ -1,6 +1,6 @@
 # Autonomous agent: Claude Code + Playwright MCP in Docker
 # Base includes browser deps + Node.js (Ubuntu Noble)
-FROM mcr.microsoft.com/playwright:v1.52.0-noble
+FROM mcr.microsoft.com/playwright:v1.58.2-noble
 
 # System dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/autonomous/entrypoint.sh
+++ b/autonomous/entrypoint.sh
@@ -83,6 +83,12 @@ fi
 if [ -f package.json ]; then
   echo ">>> Installing dependencies"
   npm ci
+  # Install Chromium for the project's @playwright/test version.
+  # The Docker image pre-installs Chromium for @playwright/mcp (different
+  # playwright-core), but E2E tests use the project's own playwright which
+  # may expect a different browser revision. Both coexist under /ms-playwright/.
+  echo ">>> Installing Chromium for project Playwright"
+  npx playwright install chromium
 fi
 
 # ── Database env for E2E tests ─────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@playwright/test": "1.52.0",
+        "@playwright/test": "1.58.2",
         "eslint": "^9",
         "eslint-plugin-react": "^7",
         "eslint-plugin-react-hooks": "^5",
@@ -1453,13 +1453,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
-      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.52.0"
+        "playwright": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8299,13 +8299,13 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
-      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.52.0"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8318,9 +8318,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
-      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "cp scripts/pre-push .git/hooks/pre-push"
   },
   "devDependencies": {
-    "@playwright/test": "1.52.0",
+    "@playwright/test": "1.58.2",
     "eslint": "^9",
     "eslint-plugin-react": "^7",
     "eslint-plugin-react-hooks": "^5",


### PR DESCRIPTION
## Summary

- Pin `@playwright/test` to exact `1.58.2` (latest stable, resolves high-severity SSL vulnerability in versions < 1.55.1)
- Update Docker base image from `v1.52.0-noble` to `v1.58.2-noble` to match
- Add `npx playwright install chromium` after `npm ci` in entrypoint so the project's Playwright browser revision is cached alongside the MCP server's separate Chromium install

The `@playwright/mcp` server bundles its own alpha `playwright-core` with a different Chromium revision. Both installs coexist under `/ms-playwright/`, so the MCP browser and E2E test browser are each resolved correctly.

## Test plan

- [x] `npm install` resolves cleanly, 0 vulnerabilities
- [x] Local CI checks pass (pre-push hook)
- [ ] Verify autonomous agent container no longer downloads Chromium at runtime
- [ ] E2E tests find the correct Chromium binary without re-downloading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
