### PR TITLE
fix: robust E2E DB teardown and agent timeout guidance

### DIFF
--- a/autonomous/prompts/execute-tasks.md
+++ b/autonomous/prompts/execute-tasks.md
@@ -73,6 +73,11 @@ To run a specific test file:
 ./scripts/run-e2e.sh e2e/auth.spec.ts
 ```
 
+**Important**: Set `timeout: 600000` on the Bash tool call (10 minutes). If the
+timeout is too short, Claude Code will auto-background the command and you will
+not be able to read the output. Do NOT pipe the output through `tail` — read the
+full output directly so you can see all test results.
+
 ### Step 4: Verify
 
 Run `./scripts/ci-check.sh` before committing — this includes type-checking, linting, **Prettier formatting**, and tests. Every check must pass.

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -12,7 +12,13 @@ cleanup() {
   [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
   wait "$SERVER_PID" 2>/dev/null || true
   echo ">>> Tearing down database..."
-  dbmate -d packages/server/db/migrations -s packages/server/db/schema.sql down
+  if timeout 30 dbmate -d packages/server/db/migrations -s packages/server/db/schema.sql down 2>&1; then
+    echo ">>> dbmate down succeeded."
+  else
+    echo ">>> dbmate down failed or timed out — dropping database to ensure clean state"
+    dbmate -d packages/server/db/migrations -s packages/server/db/schema.sql drop 2>/dev/null || true
+    dbmate -d packages/server/db/migrations -s packages/server/db/schema.sql create 2>/dev/null || true
+  fi
   echo ">>> E2E teardown complete."
 }
 trap cleanup EXIT


### PR DESCRIPTION
## Summary

- **Robust E2E teardown**: `run-e2e.sh` cleanup now wraps `dbmate down` in a 30s timeout. If it fails or hangs (e.g. FK constraint issues from runtime data), falls back to `dbmate drop` + `dbmate create` to ensure a clean DB for the next agent iteration
- **Agent timeout guidance**: Added warning to `execute-tasks.md` so agents set `timeout: 600000` on Bash tool calls for E2E scripts, preventing Claude Code from auto-backgrounding the command

## Context

The issue #115 autonomous agent hung because `dbmate down` in the cleanup trap never completed. The script never exited, Claude Code auto-backgrounded it, the agent polled indefinitely, and the outer timeout killed everything.

## Test plan

- [x] CI checks pass (type-check, lint, format, build, tests)
- [ ] Re-run agent workflow for issue #115 to verify the hang is resolved

Generated with [Claude Code](https://claude.com/claude-code)