### PR TITLE
fix(server): graceful shutdown to close DB pool

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,19 @@ const PORT = process.env.PORT ?? '3001'
 
 const app = createApp(pool)
 
-app.listen(Number(PORT), () => {
+const server = app.listen(Number(PORT), () => {
   logger.info({ port: PORT }, 'Server listening')
 })
+
+function shutdown() {
+  logger.info('Shutting down…')
+  server.close(() => {
+    pool.end().then(() => {
+      logger.info('Pool closed')
+      process.exit(0)
+    })
+  })
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)


### PR DESCRIPTION
## Summary

- Add SIGTERM/SIGINT handlers to the server entry point that close the HTTP server and end the pg Pool before exiting

## Context

The server never closed its pg Pool on termination. When `run-e2e.sh` killed the backend process, lingering pool connections prevented `dbmate drop` from succeeding:

```
db-1 | ERROR: database "mmf" is being accessed by other users
```

This was the root cause of the agent hang — even with the timeout+fallback added in #146, `dbmate drop` still fails if connections are open.

## Test plan

- [x] `npm run build -w @mmf/server` — builds clean
- [x] CI checks pass
- [ ] Re-run agent workflow to verify E2E teardown completes cleanly

Generated with [Claude Code](https://claude.com/claude-code)