### PR TITLE
fix: E2E scripts send SIGTERM directly to node process

### DIFF
--- a/scripts/e2e-check.sh
+++ b/scripts/e2e-check.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 cleanup() {
   echo ""
   echo "Tearing down…"
-  kill $(jobs -p) 2>/dev/null || true
-  wait 2>/dev/null || true
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
   docker compose -f docker-compose.dev.yml down
   echo "Done."
 }
@@ -39,8 +39,11 @@ docker run --rm --network host \
 # JWT secret for local E2E testing
 export JWT_SECRET="local-dev-jwt-secret"
 
-# Start the backend dev server in the background
-npm run dev:server &
+# Start server directly (not via npm) so kill sends SIGTERM to the node
+# process, triggering graceful shutdown and DB pool cleanup.
+SERVER_PID=""
+npx tsx packages/server/src/index.ts &
+SERVER_PID=$!
 
 # Wait for backend to accept connections
 echo "Waiting for backend…"

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -26,7 +26,9 @@ trap cleanup EXIT
 echo ">>> Migrating database..."
 dbmate -d packages/server/db/migrations -s packages/server/db/schema.sql up
 
-npm run dev:server &
+# Start server directly (not via npm) so kill sends SIGTERM to the node
+# process, triggering graceful shutdown and DB pool cleanup.
+npx tsx packages/server/src/index.ts &
 SERVER_PID=$!
 
 echo ">>> Waiting for backend..."


### PR DESCRIPTION
## Summary

- Switch `run-e2e.sh` and `e2e-check.sh` from `npm run dev:server` to `npx tsx packages/server/src/index.ts`
- This ensures `kill $SERVER_PID` sends SIGTERM directly to the node process, triggering the graceful shutdown added in #148 (`server.close()` + `pool.end()`)

## Problem

`npm run dev:server` creates a process chain: `npm` → `npm` → `tsx watch` → `node`. npm does not forward signals to child processes, so when the E2E cleanup trap ran `kill $SERVER_PID`, only the outer npm received SIGTERM. The actual node process (with our shutdown handler) never got the signal, leaving DB pool connections open and causing `dbmate drop` to fail with:

```
ERROR: database "mmf" is being accessed by other users
```

## Test plan

- [x] `npm run build` — builds clean
- [x] CI checks pass
- [ ] Re-run agent workflow to verify clean E2E teardown

Generated with [Claude Code](https://claude.com/claude-code)