### PR TITLE
fix(autonomous): unblock E2E completion with task decomposition and retry logic

### DIFF
--- a/autonomous/agent-loop.sh
+++ b/autonomous/agent-loop.sh
@@ -38,14 +38,35 @@ PR_GH_TOKEN="$GH_TOKEN_UPSTREAM"
 # ── Helpers ───────────────────────────────────────────────────
 
 # Run Claude with standard flags. Caller supplies extra args (e.g. --output-format).
+# Retries up to 3 times on transient API errors with exponential backoff.
 # Usage: run_claude [extra-flags...] -p "prompt text"
 run_claude() {
-  timeout "$TIMEOUT" claude \
-    --dangerously-skip-permissions \
-    --print \
-    --verbose \
-    "$@" \
-    2>&1 | tee "$LOG_FILE" || true
+  local max_api_retries=3
+  local attempt=0
+  local backoff=60
+
+  while [ "$attempt" -lt "$max_api_retries" ]; do
+    timeout "$TIMEOUT" claude \
+      --dangerously-skip-permissions \
+      --print \
+      --verbose \
+      "$@" \
+      2>&1 | tee "$LOG_FILE" || true
+
+    # Check for transient API errors in the output
+    if grep -qiE 'API Error|ECONNREFUSED|ECONNRESET|ETIMEDOUT|503 Service|502 Bad Gateway|rate limit' "$LOG_FILE" 2>/dev/null; then
+      attempt=$((attempt + 1))
+      if [ "$attempt" -ge "$max_api_retries" ]; then
+        echo "!!! API error persists after ${max_api_retries} retries"
+        return
+      fi
+      echo ">>> Transient API error detected — retry ${attempt}/${max_api_retries} after ${backoff}s..."
+      sleep "$backoff"
+      backoff=$((backoff * 2))
+    else
+      return
+    fi
+  done
 }
 
 # Increment the remediation attempt counter and exit 2 (stuck) if exhausted.
@@ -342,10 +363,25 @@ Upstream repo: ${UPSTREAM_REPO}"
 
     # Stuck detection — no progress and tasks remain
     if [ "$BEFORE" -eq "$AFTER" ]; then
-      echo "!!! No progress made — agent may be stuck"
+      STUCK_FILE="plan/.stuck-count"
+      STUCK_COUNT=$(cat "$STUCK_FILE" 2>/dev/null || echo 0)
+      MAX_STUCK_RETRIES=3
+
+      if [ "$STUCK_COUNT" -ge "$MAX_STUCK_RETRIES" ]; then
+        echo "!!! No progress after ${MAX_STUCK_RETRIES} retries — agent is stuck"
+        rm -f "$STUCK_FILE"
+        clear_state
+        exit 2
+      fi
+
+      echo $((STUCK_COUNT + 1)) > "$STUCK_FILE"
+      echo "!!! No progress made — retry $((STUCK_COUNT + 1))/${MAX_STUCK_RETRIES}"
       clear_state
-      exit 2
+      exit 1
     fi
+
+    # Progress was made — reset stuck counter
+    rm -f plan/.stuck-count
 
     # Push progress — fail loudly so we know about conflicts
     push_branch || true

--- a/autonomous/entrypoint.sh
+++ b/autonomous/entrypoint.sh
@@ -57,6 +57,7 @@ git fetch origin
 # BRANCH is passed from implement-milestone.sh to avoid drift
 
 if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  # Local branch exists (e.g. from a previous iteration in this container)
   git checkout "$BRANCH"
   if ! git merge upstream/main --no-edit; then
     echo "!!! Merge conflict with upstream/main"
@@ -64,7 +65,18 @@ if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
     git merge --abort
     exit 1
   fi
+elif git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then
+  # Branch exists on fork remote — resume prior work
+  echo ">>> Resuming from existing remote branch: origin/${BRANCH}"
+  git checkout -b "$BRANCH" "origin/${BRANCH}"
+  if ! git merge upstream/main --no-edit; then
+    echo "!!! Merge conflict with upstream/main"
+    echo "!!! Aborting merge — manual conflict resolution needed"
+    git merge --abort
+    exit 1
+  fi
 else
+  # Fresh branch from upstream/main
   git checkout -b "$BRANCH" upstream/main
 fi
 

--- a/autonomous/prompts/create-tasks.md
+++ b/autonomous/prompts/create-tasks.md
@@ -53,18 +53,36 @@ Brief: plan/ready/brief.md
 - **Verification**: Every task must have a concrete verification step (build, visual check, test)
 - **No gaps**: The complete checklist should fully implement the brief — nothing missing
 - **Human-only actions**: Do NOT create tasks for closing issues, closing milestones, or merging PRs. These are handled by humans outside the agent workflow. If the issue's only deliverables are human actions, create a single task that comments on the issue listing the actions the human needs to perform.
-- **E2E tests**: If the brief's Verification section includes E2E flows, include a dedicated E2E test task near the end of the checklist (before any final cleanup task). Template:
+- **E2E tests — co-locate with feature tasks**: Do NOT create a single "Write E2E tests" task. Instead, when a task implements a user-facing feature, that same task MUST include writing the E2E test for that feature.
+
+  For each feature task that has a user-visible surface:
+  - Add an E2E sub-step in the task's **Details** section
+  - The **Verify** step MUST include: `./scripts/run-e2e.sh e2e/<feature>.spec.ts` (single file, NOT the full suite)
+  - The **Files** list MUST include the E2E spec file
+
+  Example:
 
   ```text
-  - [ ] TASK-NN: Write E2E tests
-    - **Goal**: Create Playwright E2E tests covering the user flows described in the brief
-    - **Details**: Create or update files in `e2e/`. Follow patterns in existing tests (`e2e/auth.spec.ts`, `e2e/campaigns.spec.ts`). Use Playwright Test API. Tests must pass against the running local stack.
-    - **Files**: `e2e/<feature>.spec.ts`
-    - **Verify**: Run `npm run test:e2e` — all tests pass (existing + new)
+  - [ ] TASK-06: Create ReviewDetailPage with E2E coverage
+    - **Goal**: Implement the review detail page and verify it with E2E tests
+    - **Details**: Build the page component, add routes, then write Playwright E2E tests following patterns in `e2e/auth.spec.ts`
+    - **Files**: `src/pages/ReviewDetailPage.tsx`, `e2e/reviewer.spec.ts`
+    - **Verify**: `./scripts/ci-check.sh` passes AND `./scripts/run-e2e.sh e2e/reviewer.spec.ts` passes
+    - **Brief ref**: Reviewer queue section
+  ```
+
+  After ALL feature tasks are complete, add a final regression task:
+
+  ```text
+  - [ ] TASK-LAST: Full E2E regression and CI verification
+    - **Goal**: Run the complete E2E suite and CI checks to verify nothing is broken
+    - **Details**: No new code — just run the full test suite as a final gate
+    - **Files**: (none)
+    - **Verify**: `./scripts/run-e2e.sh` (all tests) AND `./scripts/ci-check.sh`
     - **Brief ref**: Verification section
   ```
 
-  For backend-only issues with no UI flows, omit this task.
+  For backend-only issues with no UI flows, omit E2E tasks entirely.
 
 ## Output Format
 

--- a/autonomous/prompts/execute-tasks.md
+++ b/autonomous/prompts/execute-tasks.md
@@ -86,7 +86,7 @@ Do NOT cherry-pick individual checks (e.g. running only `tsc` or `eslint`). Alwa
 
 If any check fails, fix the issue and re-run until all pass.
 
-If the task created or modified files in `e2e/`, also run `./scripts/run-e2e.sh` to verify E2E tests pass.
+If the task's **Verify** step includes `run-e2e.sh`, run that exact command (which may specify a single file like `./scripts/run-e2e.sh e2e/feature.spec.ts`). Only run the full suite (`./scripts/run-e2e.sh` with no args) when the task explicitly calls for it.
 
 **Visual verification**: If the task involves UI changes:
 

--- a/scripts/implement-milestone.sh
+++ b/scripts/implement-milestone.sh
@@ -266,10 +266,17 @@ while read -r ISSUE_NUMBER; do
 
   # Check if a PR already exists for this branch (restart-safe)
   FORK_OWNER=$(echo "$FORK_URL" | sed 's|github.com/||;s|/.*||')
-  EXISTING_PR=$(gh pr list --repo "${UPSTREAM_REPO}" --head "${FORK_OWNER}:${BRANCH}" --state open --json url --jq '.[0].url // empty' 2>/dev/null || true)
-  if [ -n "$EXISTING_PR" ]; then
-    echo ">>> Skipping #${ISSUE_NUMBER} — PR already exists: ${EXISTING_PR}"
-    continue
+  EXISTING_PR_JSON=$(gh pr list --repo "${UPSTREAM_REPO}" --head "${FORK_OWNER}:${BRANCH}" --state open --json url,isDraft --jq '.[0] // empty' 2>/dev/null || true)
+  if [ -n "$EXISTING_PR_JSON" ]; then
+    EXISTING_PR_URL=$(echo "$EXISTING_PR_JSON" | jq -r '.url // empty')
+    EXISTING_PR_DRAFT=$(echo "$EXISTING_PR_JSON" | jq -r '.isDraft // false')
+    if [ "$EXISTING_PR_DRAFT" = "true" ]; then
+      echo ">>> Resuming #${ISSUE_NUMBER} — draft PR needs more work: ${EXISTING_PR_URL}"
+      # Fall through to launch the container, which will resume from the branch
+    else
+      echo ">>> Skipping #${ISSUE_NUMBER} — ready PR already exists: ${EXISTING_PR_URL}"
+      continue
+    fi
   fi
 
   # Export env vars for Docker


### PR DESCRIPTION
## Summary

Addresses the systemic patterns preventing milestone 8 completion. The agent reliably completes all code tasks but gets stuck on E2E tests — issue #115 has failed 6 times at the same point.

- **Co-locate E2E tests with feature tasks** instead of one monolithic "Write E2E tests" task. Each feature task runs only its own E2E file (~30s vs 3-5min for the full suite)
- **Add stuck retry counter** (3 retries) instead of immediately killing the issue on first no-progress invocation
- **Add API error retry** with exponential backoff (60s/120s/240s) for transient ECONNREFUSED/503/rate-limit errors
- **Fix branch checkout** to resume from `origin/$BRANCH` when local ref doesn't exist (preserves prior work on container restart)
- **Resume draft PRs** in `implement-milestone.sh` instead of permanently skipping any issue with an existing PR

## Files changed

| File | Change |
|------|--------|
| `autonomous/prompts/create-tasks.md` | Replace single E2E task template with co-located per-feature guidance |
| `autonomous/prompts/execute-tasks.md` | Run specific E2E file from task's Verify step, not full suite |
| `autonomous/agent-loop.sh` | Stuck retry counter (3 attempts) + API error retry with backoff |
| `autonomous/entrypoint.sh` | Check `refs/remotes/origin/$BRANCH` before creating fresh branch |
| `scripts/implement-milestone.sh` | Resume draft PRs, only skip ready-for-review PRs |

## Test plan

- [ ] Close PR #153 and reset issue #115 branch
- [ ] Run `./scripts/implement-milestone.sh 8`
- [ ] Verify agent completes code tasks AND E2E tests by tackling them one feature at a time
- [ ] Verify stuck retry gives 2-3 more attempts if an E2E test fails
- [ ] Verify API error retry waits and resumes on transient failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
