### PR TITLE
fix(autonomous): run_claude returns non-zero on success, killing every caller

### DIFF
--- a/autonomous/agent-loop.sh
+++ b/autonomous/agent-loop.sh
@@ -66,13 +66,13 @@ run_claude() {
       attempt=$((attempt + 1))
       if [ "$attempt" -ge "$max_api_retries" ]; then
         echo "!!! API error persists after ${max_api_retries} retries"
-        return
+        return 0
       fi
       echo ">>> Transient API error detected — retry ${attempt}/${max_api_retries} after ${backoff}s..."
       sleep "$backoff"
       backoff=$((backoff * 2))
     else
-      return
+      return 0
     fi
   done
 }


### PR DESCRIPTION
## Summary

The `run_claude()` function had `return` (no argument) in its else branch after `grep` fails to find API errors. Bare `return` returns $? which is grep's exit status (1 = no match = the **success** case). With `set -euo pipefail`, every `run_claude` call site silently dies with exit 1.

This is why no post-Claude code ever executed in **any** state handler. Every invocation: Claude runs, produces output, `run_claude` returns 1, `set -e` kills the script, entrypoint sees exit 1 and treats it as 'iterate again.' The agent has been crashing after every single Claude invocation since the API retry logic was added.

**Fix**: `return 0` explicitly in both return paths.

## Test plan

- [ ] Run `./scripts/implement-milestone.sh` and verify `>>> Tasks created`, `>>> Push OK`, and `>>> Draft PR #N` messages appear in docker-compose logs
- [ ] Verify all post-Claude operations (git commit, push, PR creation) actually execute

:robot: Generated with [Claude Code](https://claude.com/claude-code)