### PR TITLE
chore: add sed to auto-approved bash commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,7 @@
       "Bash(grep:*)",
       "Bash(find:*)",
       "Bash(head:*)",
+      "Bash(sed:*)",
       "Bash(tail:*)",
       "Bash(wc:*)",
       "Bash(sort:*)",


### PR DESCRIPTION
Adds `Bash(sed:*)` to the auto-approved command list in `.claude/settings.json`.