### PR TITLE
chore: add kill, sleep, lsof, curl to Claude auto-approved commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,6 +45,10 @@
       "Bash(prettier:*)",
       "Bash(tsc:*)",
       "Bash(./scripts/*)",
+      "Bash(kill:*)",
+      "Bash(sleep:*)",
+      "Bash(lsof:*)",
+      "Bash(curl:*)",
       "mcp__playwright__*"
     ],
     "deny": ["Bash(git branch -D:*)", "Bash(gh pr merge:*)"]


### PR DESCRIPTION
## Summary
- Adds `kill`, `sleep`, `lsof`, and `curl` to the Claude Code auto-approved Bash commands in `.claude/settings.json`
- These are commonly needed during E2E test development and debugging

## Test plan
- [x] CI passes (pre-push hook ran successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)