### PR TITLE
fix(autonomous): plan files leak past milestone completion

### DIFF
--- a/autonomous/agent-loop.sh
+++ b/autonomous/agent-loop.sh
@@ -273,11 +273,11 @@ determine_state() {
     echo "done"
   elif [ -f "plan/.plan-archived" ]; then
     echo "await-ci"
+  elif [ -f "plan/.finalized" ]; then
+    echo "await-ci"
   elif [ -f "plan/ready/tasks.md" ]; then
     if grep -q '^\- \[ \]' "plan/ready/tasks.md"; then
       echo "execute-tasks"
-    elif [ -f "plan/.finalized" ]; then
-      echo "await-ci"
     else
       echo "finalize-pr"
     fi
@@ -437,7 +437,7 @@ Upstream repo: ${UPSTREAM_REPO}"
       # Side-effects (commit/push/PR) are non-critical — protect from set -e.
       # A failure here means no draft PR yet, but execute-tasks will retry.
       set +e
-      git add plan/
+      git add plan/ready/ plan/planning/
       git commit -m "chore: add plan for #${ISSUE_NUMBER}"
       if push_branch; then
         PR_NUMBER=$(create_draft_pr)


### PR DESCRIPTION
## Summary

- Promote `.finalized` check to top-level in `determine_state()` so it's reachable after `finalize-pr` deletes `plan/ready/tasks.md`. Previously, the check was nested inside the `tasks.md` branch, making it unreachable once that file was removed — state fell through to `create-brief` and restarted the entire planning cycle.
- Narrow `git add plan/` to `git add plan/ready/ plan/planning/` so internal state dotfiles (`.state`, `.finalized`, `.pr-number`, etc.) are never committed.
- Cleaned up 8 leaked plan files from PR #168.

## Test plan

- [x] Traced `determine_state()` after finalize-pr: `.finalized` now correctly resolves to `await-ci`
- [x] `./scripts/ci-check.sh` passes
- [ ] Confirm PR #168 no longer includes plan files: `gh pr diff 168 --name-only | grep plan`

Generated with [Claude Code](https://claude.com/claude-code)