### PR TITLE
chore: remove dead Campaign type alias

### DIFF
--- a/packages/client/src/api/campaigns.ts
+++ b/packages/client/src/api/campaigns.ts
@@ -33,9 +33,6 @@ export type {
   UpdateCampaignRequest,
 }
 
-// Backward-compat alias — components will be updated in TASK-05
-export type Campaign = CampaignDetail
-
 export async function fetchCampaigns(): Promise<CampaignSummary[]> {
   const response = await fetch('/v1/campaigns')
   if (!response.ok) throw new Error(`HTTP ${response.status}`)


### PR DESCRIPTION
## Summary
- Delete unused `export type Campaign = CampaignDetail` and its TASK-05 comment from `packages/client/src/api/campaigns.ts`
- No consumers exist — all imports reference `CampaignDetail` directly

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run lint` passes

Generated with [Claude Code](https://claude.com/claude-code)