### PR TITLE
refactor: extract shared authedFetch helper

### DIFF
--- a/packages/client/src/api/auth.ts
+++ b/packages/client/src/api/auth.ts
@@ -1,19 +1,8 @@
 import { UserSchema } from '@mmf/shared'
 import type { User } from '@mmf/shared'
+import { authedFetch } from './client'
 
 export type { User }
-
-function authedFetch(path: string, init: RequestInit = {}): Promise<Response> {
-  const token = localStorage.getItem('token')
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...(init.headers as Record<string, string>),
-  }
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`
-  }
-  return fetch(path, { ...init, headers })
-}
 
 export async function loginUser(
   email: string,

--- a/packages/client/src/api/campaigns.ts
+++ b/packages/client/src/api/campaigns.ts
@@ -9,18 +9,7 @@ import type {
   CreateCampaignRequest,
   UpdateCampaignRequest,
 } from '@mmf/shared'
-
-function authedFetch(path: string, init: RequestInit = {}): Promise<Response> {
-  const token = localStorage.getItem('token')
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...(init.headers as Record<string, string>),
-  }
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`
-  }
-  return fetch(path, { ...init, headers })
-}
+import { authedFetch } from './client'
 
 export type {
   CampaignSummary,

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -1,0 +1,11 @@
+export function authedFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const token = localStorage.getItem('token')
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(init.headers as Record<string, string>),
+  }
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+  return fetch(path, { ...init, headers })
+}

--- a/packages/client/src/api/notifications.ts
+++ b/packages/client/src/api/notifications.ts
@@ -1,19 +1,8 @@
 import { NotificationSchema } from '@mmf/shared'
 import type { Notification } from '@mmf/shared'
+import { authedFetch } from './client'
 
 export type { Notification }
-
-function authedFetch(path: string, init: RequestInit = {}): Promise<Response> {
-  const token = localStorage.getItem('token')
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...(init.headers as Record<string, string>),
-  }
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`
-  }
-  return fetch(path, { ...init, headers })
-}
 
 export async function fetchNotifications(): Promise<Notification[]> {
   const response = await authedFetch('/v1/notifications')


### PR DESCRIPTION
## Summary
- Create `packages/client/src/api/client.ts` with the shared `authedFetch` function
- Update imports in `auth.ts`, `campaigns.ts`, `notifications.ts` to use the shared helper
- Delete the duplicated local `authedFetch` from each file

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run lint` passes

Generated with [Claude Code](https://claude.com/claude-code)