### PR TITLE
fix: standardise process.env bracket notation

### DIFF
--- a/packages/server/src/db/pool.ts
+++ b/packages/server/src/db/pool.ts
@@ -3,7 +3,7 @@ import pg from 'pg'
 const { Pool } = pg
 
 export const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString: process.env['DATABASE_URL'],
 })
 
 pool.on('error', (err) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,7 +3,7 @@ import { pool } from './db/pool.js'
 import { createApp } from './app.js'
 
 const logger = pino({ name: 'server' })
-const PORT = process.env.PORT ?? '3001'
+const PORT = process.env['PORT'] ?? '3001'
 
 const app = createApp(pool)
 


### PR DESCRIPTION
## Summary
- `process.env.PORT` -> `process.env['PORT']` in `packages/server/src/index.ts`
- `process.env.DATABASE_URL` -> `process.env['DATABASE_URL']` in `packages/server/src/db/pool.ts`
- Aligns with codebase convention and prepares for `noUncheckedIndexedAccess`

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run lint` passes

Generated with [Claude Code](https://claude.com/claude-code)