### PR TITLE
fix: add JWT_SECRET to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ DATABASE_URL=postgresql://mmf:mmf@localhost:5432/mmf
 # Server
 PORT=3001
 NODE_ENV=development
+
+# Auth — signing key for JWT tokens (any string works locally)
+JWT_SECRET=local-dev-jwt-secret


### PR DESCRIPTION
## Summary
- Add `JWT_SECRET=local-dev-jwt-secret` with descriptive comment to `.env.example`
- Prevents new developers from hitting runtime errors due to missing config

## Test plan
- [x] `npm run lint` passes

Generated with [Claude Code](https://claude.com/claude-code)