### PR TITLE
fix: align Playwright Dockerfile version

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -2,7 +2,7 @@
 # Used by docker-compose.yml (run app) and docker-compose.e2e.yml (run checks).
 # No host dependencies beyond Docker.
 FROM ghcr.io/amacneil/dbmate AS dbmate
-FROM mcr.microsoft.com/playwright:v1.52.0-noble
+FROM mcr.microsoft.com/playwright:v1.58.0-noble
 
 COPY --from=dbmate /usr/local/bin/dbmate /usr/local/bin/dbmate
 


### PR DESCRIPTION
## Summary
- Update Playwright base image in `Dockerfile.e2e` from `v1.52.0-noble` to `v1.58.0-noble`
- Aligns with `@playwright/test` 1.58.2 in `package.json`

## Test plan
- [x] Visual review of version alignment
- [ ] `docker build -f Dockerfile.e2e .` (optional — full E2E)

Generated with [Claude Code](https://claude.com/claude-code)