### PR TITLE
fix: add missing tsconfig project references

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "files": [],
-  "references": [{ "path": "./packages/client" }]
+  "references": [
+    { "path": "./packages/client" },
+    { "path": "./packages/server" },
+    { "path": "./packages/shared" }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `{ "path": "./packages/server" }` and `{ "path": "./packages/shared" }` to root `tsconfig.json` references
- Enables `tsc -b` to type-check all three workspaces from the root

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] `npm run build` passes

Generated with [Claude Code](https://claude.com/claude-code)