### PR TITLE
fix: replace console with pino logger in server

### DIFF
--- a/packages/server/src/campaigns/audit.ts
+++ b/packages/server/src/campaigns/audit.ts
@@ -1,4 +1,7 @@
 import { Pool } from 'pg'
+import pino from 'pino'
+
+const logger = pino({ name: 'audit' })
 
 export interface AuditEventInput {
   action: string
@@ -41,6 +44,6 @@ export async function writeAuditEvent(pool: Pool, event: AuditEventInput): Promi
       ]
     )
   } catch (err) {
-    console.error('[audit] Failed to write audit event:', err)
+    logger.error({ err }, 'Failed to write audit event')
   }
 }

--- a/packages/server/src/db/pool.ts
+++ b/packages/server/src/db/pool.ts
@@ -1,13 +1,15 @@
 import pg from 'pg'
+import pino from 'pino'
 
 const { Pool } = pg
+const logger = pino({ name: 'pool' })
 
 export const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 })
 
 pool.on('error', (err) => {
-  console.error('[pool] Unexpected error on idle client:', err)
+  logger.error({ err }, 'Unexpected error on idle client')
 })
 
 export default pool


### PR DESCRIPTION
## Summary
- Replace `console.error` in `packages/server/src/db/pool.ts` with structured pino logger
- Replace `console.error` in `packages/server/src/campaigns/audit.ts` with structured pino logger
- Intentional STUB `console.log` markers in `routes.ts` left as-is (demo markers)

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run lint` passes

Generated with [Claude Code](https://claude.com/claude-code)