### PR TITLE
chore: align TypeScript version specifiers

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -35,7 +35,7 @@
     "pino-pretty": "^13",
     "supertest": "^7",
     "tsx": "^4",
-    "typescript": "^5",
+    "typescript": "^5.7.2",
     "vitest": "^3"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,6 @@
     "zod": "^3"
   },
   "devDependencies": {
-    "typescript": "^5"
+    "typescript": "^5.7.2"
   }
 }


### PR DESCRIPTION
## Summary
- Pin `typescript` from `^5` to `^5.7.2` in `packages/server/package.json` and `packages/shared/package.json`
- Aligns with the client package which already specifies `^5.7.2`

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes

Generated with [Claude Code](https://claude.com/claude-code)