### PR TITLE
feat(autonomous-demo): self-contained autonomous agent demo in Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,8 @@ jobs:
         run: npm run test:e2e
 
       - name: Audit
-        run: npm audit
+        # Fail only on high/critical advisories in production dependencies.
+        # Dev-only tools (vitest, markdownlint-cli2 -> markdown-it/yaml) and an
+        # unfixable moderate in a prod transitive (js-yaml via swagger-jsdoc, no
+        # patched release exists) don't block CI; prod high/critical still do.
+        run: npm audit --omit=dev --audit-level=high

--- a/autonomous-demo/.dockerignore
+++ b/autonomous-demo/.dockerignore
@@ -1,0 +1,5 @@
+.env
+logs/
+screenshots/
+PROMPT.md
+README.md

--- a/autonomous-demo/.env.example
+++ b/autonomous-demo/.env.example
@@ -1,0 +1,19 @@
+# ── Claude auth (REQUIRED) ───────────────────────────────────
+# Use ONE of the following.
+#
+# Option A — OAuth token (recommended). Generate with:  claude setup-token
+CLAUDE_CODE_OAUTH_TOKEN=your-oauth-token
+#
+# Option B — Anthropic API key (uncomment to use instead):
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# ── Guardrails (optional — these are the safety boundary) ────
+MAX_ITERATIONS=30          # hard cap on outer agent-loop iterations
+MAX_TURNS=40               # cost cap: max turns per Claude invocation
+TIMEOUT_SECONDS=1800       # wall-clock timeout per Claude invocation
+COOLDOWN_SECONDS=3         # pause between iterations
+ROLLBACK_ON_FAILURE=true   # discard a task's changes if the verify gate fails
+MAX_ROLLBACKS=3            # give up on a task after this many rollbacks
+
+# ── Optional: name the container ─────────────────────────────
+# CONTAINER_NAME=autonomous-demo

--- a/autonomous-demo/.gitignore
+++ b/autonomous-demo/.gitignore
@@ -1,0 +1,4 @@
+.env
+logs/
+screenshots/
+.DS_Store

--- a/autonomous-demo/Dockerfile
+++ b/autonomous-demo/Dockerfile
@@ -1,0 +1,49 @@
+# Self-contained autonomous DEMO: Claude Code + Playwright MCP in Docker.
+# Runs the full plan -> tasks -> build -> verify loop locally, no GitHub required.
+# Base image includes browser deps + Node.js (Ubuntu Noble).
+FROM mcr.microsoft.com/playwright:v1.58.2-noble
+
+# System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    jq \
+    lsof \
+    sudo \
+  && rm -rf /var/lib/apt/lists/*
+
+# DBMate — database migration tool (applies the app's Postgres schema)
+RUN curl -fsSL https://github.com/amacneil/dbmate/releases/latest/download/dbmate-linux-amd64 \
+      -o /usr/local/bin/dbmate \
+  && chmod +x /usr/local/bin/dbmate
+
+# Claude Code CLI + Playwright MCP server (global).
+# Base image ships Node 20 + npm 10; npm workspaces (this monorepo) work fine.
+RUN npm install -g @anthropic-ai/claude-code @playwright/mcp
+
+# Non-root user — Claude Code refuses --dangerously-skip-permissions as root.
+RUN useradd -m -s /bin/bash agent \
+  && echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Pre-create ~/.claude so any future volume mounts don't create it as root.
+RUN mkdir -p /home/agent/.claude \
+  && chown -R agent:agent /home/agent
+
+WORKDIR /workspace
+RUN chown agent:agent /workspace
+
+USER agent
+
+# Install Chromium using the MCP server's bundled playwright-core (revision must
+# match what the MCP server looks for at runtime). Placed before the COPY steps
+# so editing scripts/prompts doesn't bust this slow cache layer.
+RUN node /usr/lib/node_modules/@playwright/mcp/node_modules/playwright-core/cli.js install chromium
+
+# Copy scripts (after Chromium install so edits here don't trigger a re-download)
+COPY --chown=agent:agent entrypoint.sh demo-loop.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/demo-loop.sh
+
+# Copy the per-state prompts into the image
+COPY --chown=agent:agent prompts/ /usr/local/share/prompts/
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/autonomous-demo/PROMPT.md
+++ b/autonomous-demo/PROMPT.md
@@ -1,13 +1,13 @@
 # Feature Request
 
-> This is the brief the autonomous agent will build. Replace everything below
-> with your own feature when you want — but keep it concrete: say what the user
-> should be able to do, where it lives in the app, and how to tell it works.
+> This is the request the **Planning Agent** turns into a structured plan, which
+> the **Coding Agent** then executes step by step (see the README's "Plan-First
+> Orchestration"). Replace it with your own — keep it concrete: what the user
+> should be able to do, where it lives, and how to tell it works.
 >
-> The example below is **Exercise 03 — Trending Missions**. It is a good demo
-> because it spans the full stack (database → server → shared types → client →
-> UI → tests), so the planner produces a multi-step `tasks.md` the loop then
-> executes one task at a time.
+> The default below is **Exercise 03 — Trending Missions**: a full-stack feature
+> that spans database → server → shared types → client → UI → tests, so the
+> planner produces a multi-step `tasks.md` the loop executes one task at a time.
 
 ## Trending Missions
 
@@ -39,18 +39,30 @@ the main campaign grid.
 - The change spans server, shared, and client packages.
 
 <!--
-Other ready-made exercises you can paste here instead:
+Other ready-made options — paste one in place of the section above:
 
-  • Exercise 01 — Refactor-Rename:
-    Rename the domain term "Campaign" to "Proposal" across the entire codebase
-    (TypeScript types, SQL tables/columns, API routes, React components, and the
-    spec at specs/domain/campaign.md). Write a proper SQL migration respecting FK
-    constraints. Done when ci-check passes and GET /v1/proposals returns data.
+  • SMALL VISUAL (fast, ~1-2 tasks, produces a UI screenshot):
+    Add an always-visible site footer to the web app. Create a `Footer`
+    component under packages/client/src/ (existing patterns + Tailwind design
+    tokens) showing the tagline "Every dollar moves the launch window closer"
+    and "© 2026 Mars Mission Fund", mounted at the bottom of the app layout so
+    it appears on every page. No backend/DB/deps, no E2E — a screenshot is the
+    verification. Done when ci-check passes and the footer is visible at
+    http://localhost:5173.
 
-  • Exercise 02 — Cross-Cutting Concern (Observability):
-    Add structured HTTP request logging to the server. Every request logs method,
-    path, status code, response time (ms), and correlation ID as JSON using the
-    existing pino logger. The middleware must sit AFTER the correlationId
-    middleware in app.ts. Add tests asserting the log fields. (Backend-only — no
-    screenshots needed.)
+  • UPGRADE / MIGRATION (best for showing Plan-First Orchestration — breaking
+    changes, affected files, migration steps, verification criteria):
+    Migrate the domain term "Campaign" to "Proposal" across the entire codebase
+    — TypeScript types, SQL tables/columns, API routes (/v1/campaigns ->
+    /v1/proposals), React components, and the spec at specs/domain/campaign.md.
+    Write a proper SQL migration respecting FK constraints. Done when ci-check
+    passes, the E2E/UI still works, and GET /v1/proposals returns the data.
+    (This is workshop Exercise 01 — see ../01-exercise-rename.md.)
+
+  • CROSS-CUTTING / BACKEND-ONLY (no screenshots):
+    Add structured HTTP request logging to the server. Every request logs
+    method, path, status code, response time (ms), and correlation ID as JSON
+    using the existing pino logger. The middleware must sit AFTER the
+    correlationId middleware in app.ts. Add tests asserting the log fields.
+    (Workshop Exercise 02 — see ../02-exercise-olly.md.)
 -->

--- a/autonomous-demo/PROMPT.md
+++ b/autonomous-demo/PROMPT.md
@@ -1,0 +1,56 @@
+# Feature Request
+
+> This is the brief the autonomous agent will build. Replace everything below
+> with your own feature when you want — but keep it concrete: say what the user
+> should be able to do, where it lives in the app, and how to tell it works.
+>
+> The example below is **Exercise 03 — Trending Missions**. It is a good demo
+> because it spans the full stack (database → server → shared types → client →
+> UI → tests), so the planner produces a multi-step `tasks.md` the loop then
+> executes one task at a time.
+
+## Trending Missions
+
+Add a **"Trending Missions"** section to the Explore page. It shows the 3 most
+popular live campaigns by contributor count, displayed as a horizontal row above
+the main campaign grid.
+
+### What to build
+
+- **Database**: a query against the `campaigns` table, filtered to `Live`
+  status, ordered by `contributor_count` descending, limited to 3.
+- **Server**: a new endpoint `GET /v1/campaigns/trending` that returns the top 3
+  as campaign summaries. Follow the existing route/query conventions.
+- **Shared types**: a type for the trending response (or reuse `CampaignSummary`).
+- **Client API**: a new fetch function in `packages/client/src/api/campaigns.ts`,
+  following the existing pattern.
+- **UI**: a new section at the top of the Explore page
+  (`packages/client/src/pages/ExplorePage.tsx`), using existing component
+  primitives and design tokens.
+- **Tests**: server and client tests for the new endpoint and component, plus a
+  Playwright E2E test for the Explore page.
+
+### Done when
+
+- `./scripts/ci-check.sh` passes (type-check, lint, format, build, unit tests).
+- Visiting `/explore` shows a **Trending Missions** row above the main grid.
+- `GET /v1/campaigns/trending` returns the top 3 live campaigns by contributor
+  count.
+- The change spans server, shared, and client packages.
+
+<!--
+Other ready-made exercises you can paste here instead:
+
+  • Exercise 01 — Refactor-Rename:
+    Rename the domain term "Campaign" to "Proposal" across the entire codebase
+    (TypeScript types, SQL tables/columns, API routes, React components, and the
+    spec at specs/domain/campaign.md). Write a proper SQL migration respecting FK
+    constraints. Done when ci-check passes and GET /v1/proposals returns data.
+
+  • Exercise 02 — Cross-Cutting Concern (Observability):
+    Add structured HTTP request logging to the server. Every request logs method,
+    path, status code, response time (ms), and correlation ID as JSON using the
+    existing pino logger. The middleware must sit AFTER the correlationId
+    middleware in app.ts. Add tests asserting the log fields. (Backend-only — no
+    screenshots needed.)
+-->

--- a/autonomous-demo/README.md
+++ b/autonomous-demo/README.md
@@ -1,0 +1,265 @@
+# Autonomous Agent in Docker — Demo
+
+A **self-contained** demo of an autonomous coding agent. Drop a feature request
+into `PROMPT.md`, run `docker compose up`, and watch Claude Code plan the work,
+break it into tasks, implement them one at a time, test and verify each change,
+and capture screenshots — all inside a throwaway container.
+
+No GitHub account, fork, or tokens required. The only credential you need is a
+Claude token. The repo is **bind-mounted** into the container, so the agent edits
+your real files on a throwaway demo branch — every change shows up live in your
+editor (VS Code). Only the `node_modules` are container-only, so your host install
+is never touched.
+
+---
+
+## The four pillars (what this demonstrates)
+
+> **Build an Autonomous Agent in Docker.** Let an autonomous agent do the work;
+> Docker provides the safety boundary.
+
+| # | Pillar | Where it lives here |
+|---|--------|---------------------|
+| 01 | **Containerise** — codebase + test suite + Playwright in one image | `Dockerfile`, `docker-compose.yml` |
+| 02 | **Agent Loop** — analyse → change → test → verify → repeat | `demo-loop.sh` + `prompts/` |
+| 03 | **Guardrails** — token/cost cap, iteration cap, rollback on test failure | env vars in `.env`, enforced in `demo-loop.sh` |
+| 04 | **Observe** — watch where it gets stuck and where it succeeds | streamed logs + `logs/` + `screenshots/` |
+
+> Some runs will hit the **"Loop of Death"** — the agent thrashing on a task it
+> can't finish. That is the point of the demo: the guardrails (iteration cap,
+> rollback, stuck-detection) are what turn that failure into a safe, bounded
+> stop instead of an infinite spend.
+
+---
+
+## Prerequisites
+
+- **Docker** and Docker Compose. Nothing else — no Node, no Postgres on the host.
+- A **Claude credential**: either a Claude Code OAuth token or an Anthropic API key.
+
+Generate an OAuth token on a machine that has the Claude CLI:
+
+```bash
+claude setup-token
+```
+
+---
+
+## Quick start
+
+All commands run from this `autonomous-demo/` directory.
+
+```bash
+# 1. Configure credentials + guardrails
+cp .env.example .env
+#    then edit .env and paste your CLAUDE_CODE_OAUTH_TOKEN
+
+# 2. Edit the feature request (an example is already provided)
+#    open PROMPT.md and describe what you want built
+
+# 3. Run it — build the image, start Postgres, run the agent loop
+docker compose up --build
+```
+
+Then watch the loop work. When it finishes, inspect the results:
+
+```bash
+cat logs/SUMMARY.md        # commits, files changed, screenshots
+open screenshots/          # visual proof the feature works (macOS)
+less logs/changes.diff     # the full diff the agent produced
+```
+
+### Watch it work in your editor
+
+Because the repo is bind-mounted, the agent's edits land in your real working
+tree as it goes. Open the folder in VS Code and watch files change live, or open
+**Source Control** to see the running diff on the demo branch. The branch name is
+printed near the top of the run (`>>> Working on branch: demo/<timestamp>`).
+
+### Reset after a run
+
+The agent commits its work to a **demo branch in your repo**. Once you've
+reviewed the diff, return to your previous branch and clean up:
+
+```bash
+git checkout main                  # or whatever branch you started on
+git branch -D demo/<timestamp>     # the demo branch from the run output
+```
+
+To reset the container side (fresh container, DB, node_modules, outputs):
+
+```bash
+docker compose down -v             # also removes the container-only node_modules volumes
+rm -rf logs screenshots
+```
+
+---
+
+## How to provide a prompt
+
+The agent builds whatever is in **`PROMPT.md`**. That is the single input.
+
+Write it like a brief for a junior engineer. The clearer the "done when", the
+better the agent's plan:
+
+```markdown
+# Feature Request
+
+## <Feature name>
+
+<What the user should be able to do, and where it lives in the app.>
+
+### What to build
+- ...
+
+### Done when
+- `./scripts/ci-check.sh` passes
+- <observable behaviour, e.g. "visiting /explore shows a Trending row">
+```
+
+### Ready-made examples (workshop exercises)
+
+`PROMPT.md` ships with **Exercise 03 — Trending Missions** because it spans the
+full stack and therefore produces a multi-step plan. You can paste any of these
+instead (see the commented block at the bottom of `PROMPT.md`):
+
+| Exercise | What it does | Good for showing |
+|----------|--------------|------------------|
+| **03 — Trending Missions** (default) | New full-stack feature on the Explore page | A long `tasks.md`, UI screenshots, E2E tests |
+| **01 — Refactor-Rename** | Rename `Campaign` → `Proposal` across the codebase + a SQL migration | Large, mechanical, cross-cutting edits |
+| **02 — Observability** | Add structured request logging middleware | A focused backend-only change (no screenshots) |
+
+The full exercise descriptions live in the repo root: `../01-exercise-rename.md`,
+`../02-exercise-olly.md`, `../03-exercise-new-feature.md`.
+
+---
+
+## How the loop works (Pillar 02)
+
+`demo-loop.sh` is a small **state machine**. The outer loop in `entrypoint.sh`
+calls it repeatedly; each call advances one state and exits, so the loop is
+restart-safe (state is inferred from files on disk).
+
+```text
+            ┌─────────────┐
+PROMPT.md → │ create-brief │  analyse the request → plan/ready/brief.md
+            └──────┬──────┘
+                   ▼
+            ┌─────────────┐
+            │ create-tasks │  decompose the brief → plan/ready/tasks.md
+            └──────┬──────┘
+                   ▼
+            ┌──────────────┐   one task per iteration:
+            │ execute-tasks │   implement → ci-check → screenshot → commit
+            └──────┬───────┘   ↺ repeats until every task is [x]
+                   ▼               (verify gate + rollback after each task)
+            ┌─────────────┐
+            │   verify     │  full ci-check + Playwright screenshots + summary
+            └──────┬──────┘
+                   ▼
+                 done ✔
+```
+
+Each state hands Claude a focused prompt from `prompts/`:
+
+| State | Prompt | Job |
+|-------|--------|-----|
+| `create-brief` | `prompts/create-brief.md` | Turn `PROMPT.md` into a brief |
+| `create-tasks` | `prompts/create-tasks.md` | Decompose the brief into `tasks.md` |
+| `execute-tasks` | `prompts/execute-tasks.md` | Implement + verify ONE task, then stop |
+| `verify` | `prompts/verify.md` | Prove the feature works, capture screenshots |
+| (CI repair) | `prompts/remediate.md` | Fix a failing `ci-check.sh` |
+
+Claude runs with `--dangerously-skip-permissions` (safe — it is sandboxed in the
+container) and the Playwright MCP server for browser-driven verification.
+
+---
+
+## Guardrails (Pillar 03)
+
+All configurable in `.env`. These are the safety boundary — tune them live to
+show their effect.
+
+| Variable | Default | What it caps |
+|----------|---------|--------------|
+| `MAX_ITERATIONS` | `30` | Total outer-loop iterations before a hard stop |
+| `MAX_TURNS` | `40` | Turns per Claude invocation — the **cost cap** |
+| `TIMEOUT_SECONDS` | `1800` | Wall-clock per Claude invocation |
+| `ROLLBACK_ON_FAILURE` | `true` | If the verify gate fails after a task, `git reset --hard` discards that task's changes |
+| `MAX_ROLLBACKS` | `3` | Give up on a single task after this many rollbacks (stops the Loop of Death) |
+| `COOLDOWN_SECONDS` | `3` | Pause between iterations |
+
+**Rollback on test failure** is the headline guardrail: after a task is
+implemented, the loop runs a fast type-check/build gate. If it fails, the broken
+work is rolled back to the pre-task commit and retried — bounded by
+`MAX_ROLLBACKS`. The agent never builds on top of broken code, and it can never
+spin forever.
+
+There are also two automatic backstops: per-state repeat detection and
+per-task "no-progress" detection. Any of them can end the run with a **stuck**
+exit, which `entrypoint.sh` reports clearly.
+
+---
+
+## What to observe (Pillar 04)
+
+While it runs, watch the streamed output for the state banners
+(`>>> State: execute-tasks`), the task counter (`Tasks remaining: 6 -> 5`), and
+the guardrail messages (`Verify gate FAILED — rolling back...`).
+
+Good questions for the audience:
+
+- Where did it get stuck, and which guardrail caught it?
+- Did it roll back? How many times before it found a working approach?
+- Did the screenshots actually show the feature working?
+
+Everything is persisted on the host for review after the run:
+
+```text
+autonomous-demo/
+├── logs/
+│   ├── SUMMARY.md            # commits, files changed, screenshots, rollback count
+│   ├── changes.diff          # full diff vs main
+│   ├── tasks.md              # the plan the agent generated
+│   ├── demo-<state>-*.log    # raw Claude output per state
+│   ├── ci-check-*.log        # CI runs
+│   └── gate-*.log            # verify-gate runs (rollback decisions)
+└── screenshots/
+    ├── TASK-01.png ...        # per-task visual checks
+    └── VERIFY-*.png           # final feature confirmation
+```
+
+---
+
+## Files in this folder
+
+```text
+autonomous-demo/
+├── README.md            # this file
+├── Dockerfile           # Pillar 01: Claude Code + Playwright MCP + dbmate + repo deps
+├── docker-compose.yml   # Pillar 01: agent + Postgres, volume mounts
+├── entrypoint.sh        # use mounted repo, install deps, migrate DB, run the loop
+├── demo-loop.sh         # Pillars 02/03/04: the state machine + guardrails
+├── prompts/             # one prompt per state
+├── PROMPT.md            # ← YOUR feature request (the only input)
+├── .env.example         # credentials + guardrail config
+├── .gitignore           # ignores .env, logs/, screenshots/
+└── .dockerignore
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `No Claude credentials` on start | Set `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) in `.env`. |
+| `PROMPT.md is missing or empty` | Put your feature request in `PROMPT.md`. |
+| Agent stops with **"stuck"** | Expected for hard prompts — that's the guardrails working. Read `logs/` to see where; simplify `PROMPT.md` or raise `MAX_ITERATIONS` / `MAX_ROLLBACKS`. |
+| Slow first run | The image downloads Chromium and runs `npm ci`. Subsequent runs reuse the build cache. |
+| Want to re-run cleanly | `docker compose down -v && rm -rf logs screenshots`. |
+| Out of memory | The agent has a 4 GB limit in `docker-compose.yml`; raise `mem_limit` if your machine allows. |
+
+> **Cost note:** an autonomous run makes many model calls. `MAX_TURNS`,
+> `MAX_ITERATIONS`, and `TIMEOUT_SECONDS` bound the spend — keep them modest for
+> a live demo and raise them only if you want the agent to tackle bigger work.

--- a/autonomous-demo/README.md
+++ b/autonomous-demo/README.md
@@ -170,6 +170,21 @@ Each state hands Claude a focused prompt from `prompts/`:
 | `verify` | `prompts/verify.md` | Prove the feature works, capture screenshots |
 | (CI repair) | `prompts/remediate.md` | Fix a failing `ci-check.sh` |
 
+### Plan-First Orchestration (two agents)
+
+The loop deliberately splits into a **Planning Agent** and a **Coding Agent**
+that run as *separate* Claude invocations with separate context — the executor
+sees only the written plan (`brief.md` + `tasks.md`), never the planning
+conversation. The plan is an explicit, reviewable artifact, not a vague
+instruction.
+
+| Aspect | Planning Agent (`create-brief` → `create-tasks`) | Coding Agent (`execute-tasks` → `verify`) |
+| ------ | ------------------------------------------------ | ----------------------------------------- |
+| Input | the request in `PROMPT.md` | the plan (`brief.md` + `tasks.md`) |
+| Produces | a structured plan: breaking changes, affected files, migration steps, and verification criteria (which tests must pass) | working code, committed step by step |
+| In Docker | writes no code | executes each step and runs the tests |
+| Playwright | — | verifies the UI hasn't broken |
+
 Claude runs with `--dangerously-skip-permissions` (safe — it is sandboxed in the
 container) and the Playwright MCP server for browser-driven verification.
 

--- a/autonomous-demo/demo-loop.sh
+++ b/autonomous-demo/demo-loop.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ════════════════════════════════════════════════════════════════════════════
+#  Pillar 02 — the AGENT LOOP, plus Pillars 03/04 (Guardrails / Observe).
+#
+#  One state transition per invocation. The outer loop in entrypoint.sh calls
+#  this repeatedly. State is inferred from files on disk so the loop is
+#  restart-safe.
+#
+#  State graph (each state -> next on success):
+#    create-brief -> create-tasks -> execute-tasks -> verify -> done
+#
+#  Exit codes:  0 = done   1 = iterate again   2 = stuck (guardrail tripped)
+# ════════════════════════════════════════════════════════════════════════════
+
+REPO_DIR="/workspace/repo"
+PROMPTS_DIR="/usr/local/share/prompts"
+LOG_DIR="/workspace/logs"
+SCREENSHOT_DIR="/screenshots"
+PROMPT_FILE="/workspace/PROMPT.md"
+
+BASE_BRANCH="${BASE_BRANCH:-origin/main}"
+TIMEOUT="${TIMEOUT_SECONDS:-1800}"
+MAX_TURNS="${MAX_TURNS:-40}"
+MAX_REMEDIATION_ATTEMPTS="${MAX_REMEDIATION_ATTEMPTS:-3}"
+MAX_ROLLBACKS="${MAX_ROLLBACKS:-3}"
+ROLLBACK_ON_FAILURE="${ROLLBACK_ON_FAILURE:-true}"
+
+# Verify gate run after each task (Pillar 03). Kept lighter than the full
+# ci-check so per-task iteration stays fast; the final verify state runs the
+# complete ci-check.sh.
+GATE_CMD="${GATE_CMD:-npm run build -w @mmf/shared && npx tsc -b --noEmit && npx tsc --noEmit -p packages/server/tsconfig.json}"
+
+mkdir -p "$LOG_DIR" "$SCREENSHOT_DIR"
+cd "$REPO_DIR"
+mkdir -p plan/ready plan/planning
+
+# Clear any stale .state lock from a crashed invocation (filesystem is authoritative).
+rm -f plan/.state
+
+# ── Helper: run Claude with standard flags + guardrails + retries ────────────
+run_claude() {
+  local turn_flag=()
+  [ -n "$MAX_TURNS" ] && turn_flag=(--max-turns "$MAX_TURNS")  # Pillar 03: cost cap
+
+  local max_api_retries=3 attempt=0 backoff=60
+  while [ "$attempt" -lt "$max_api_retries" ]; do
+    timeout "$TIMEOUT" claude \
+      --dangerously-skip-permissions \
+      --print \
+      --verbose \
+      "${turn_flag[@]}" \
+      "$@" \
+      2>&1 | tee "$LOG_FILE" || true
+
+    if grep -qiE 'API Error|ECONNREFUSED|ECONNRESET|ETIMEDOUT|503 Service|502 Bad Gateway|rate limit' "$LOG_FILE" 2>/dev/null; then
+      attempt=$((attempt + 1))
+      [ "$attempt" -ge "$max_api_retries" ] && { echo "!!! API error persists after ${max_api_retries} retries"; return 0; }
+      echo ">>> Transient API error — retry ${attempt}/${max_api_retries} after ${backoff}s..."
+      sleep "$backoff"; backoff=$((backoff * 2))
+    else
+      return 0
+    fi
+  done
+}
+
+safety_commit() {
+  local msg="${1:-chore: save demo progress}"
+  if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    git add -A
+    git commit -m "$msg" || true
+  fi
+}
+
+check_remediation_attempts() {
+  local description="$1" attempts_file="plan/.fix-attempts" attempts
+  attempts=$(cat "$attempts_file" 2>/dev/null || echo 0)
+  if [ "$attempts" -ge "$MAX_REMEDIATION_ATTEMPTS" ]; then
+    echo "!!! ${description} after ${MAX_REMEDIATION_ATTEMPTS} attempts — stuck"
+    exit 2
+  fi
+  echo $((attempts + 1)) > "$attempts_file"
+  echo ">>> ${description} — attempt $((attempts + 1))/${MAX_REMEDIATION_ATTEMPTS}"
+}
+
+set_state()   { mkdir -p plan; echo "$1" > plan/.state; }
+clear_state() { rm -f plan/.state; }
+
+# Guard against any state spinning without progress (Pillar 04: detect Loop of Death).
+check_state_repeat() {
+  local state="$1" count_file="plan/.state-repeat" last_file="plan/.last-state"
+  local max_repeats last_state count
+  case "$state" in
+    execute-tasks) return ;;       # has its own stuck + rollback detection
+    verify)        max_repeats=8 ;;
+    *)             max_repeats=3 ;;
+  esac
+  last_state=$(cat "$last_file" 2>/dev/null || echo "")
+  if [ "$state" = "$last_state" ]; then
+    count=$(cat "$count_file" 2>/dev/null || echo 0); count=$((count + 1))
+    echo "$count" > "$count_file"
+    if [ "$count" -ge "$max_repeats" ]; then
+      echo "!!! State '${state}' repeated ${count}x without progress — stuck"
+      exit 2
+    fi
+  else
+    echo "$state" > "$last_file"; echo 1 > "$count_file"
+  fi
+}
+
+determine_state() {
+  if [ -f "plan/.state" ];    then cat "plan/.state"; return; fi
+  if [ -f "plan/.verified" ]; then echo "done";       return; fi
+  if [ -f "plan/ready/tasks.md" ]; then
+    if grep -q '^\- \[ \]' "plan/ready/tasks.md"; then echo "execute-tasks"; else echo "verify"; fi
+    return
+  fi
+  if [ -f "plan/ready/brief.md" ]; then echo "create-tasks"; return; fi
+  echo "create-brief"
+}
+
+write_summary() {
+  {
+    echo "# Demo Run Summary"
+    echo
+    echo "- Branch: \`$(git rev-parse --abbrev-ref HEAD)\`"
+    echo "- Base:   \`${BASE_BRANCH}\`"
+    echo "- Rollbacks: $(cat plan/.rollback-total 2>/dev/null || echo 0)"
+    echo
+    echo "## Commits"
+    echo '```'
+    git log --oneline "${BASE_BRANCH}..HEAD" 2>/dev/null || true
+    echo '```'
+    echo
+    echo "## Files changed"
+    echo '```'
+    git diff --stat "${BASE_BRANCH}...HEAD" 2>/dev/null || true
+    echo '```'
+    echo
+    echo "## Screenshots captured"
+    echo '```'
+    ls -1 "$SCREENSHOT_DIR" 2>/dev/null || echo "(none)"
+    echo '```'
+  } > "$LOG_DIR/SUMMARY.md"
+  git diff "${BASE_BRANCH}...HEAD" > "$LOG_DIR/changes.diff" 2>/dev/null || true
+  cp -f plan/ready/tasks.md "$LOG_DIR/tasks.md" 2>/dev/null || true
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+STATE=$(determine_state)
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG_FILE="${LOG_DIR}/demo-${STATE}-${TIMESTAMP}.log"
+echo ">>> State: ${STATE}"
+echo ">>> Log:   ${LOG_FILE}"
+
+check_state_repeat "$STATE"
+
+FEATURE_REQUEST=$(cat "$PROMPT_FILE")
+
+case "$STATE" in
+
+  # ── analyse: turn the feature request into a brief ─────────────────────────
+  create-brief)
+    set_state create-brief
+    run_claude -p "$(cat "${PROMPTS_DIR}/create-brief.md")
+
+## Feature Request (from PROMPT.md)
+
+${FEATURE_REQUEST}"
+
+    if [ ! -f "plan/ready/brief.md" ] && [ -f "plan/planning/brief.md" ]; then
+      cp plan/planning/brief.md plan/ready/brief.md
+      echo ">>> Promoted planning brief to ready"
+    fi
+    if [ -f "plan/ready/brief.md" ]; then
+      echo ">>> Brief ready"; clear_state; exit 1
+    fi
+    echo "!!! No brief produced"; clear_state; exit 2
+    ;;
+
+  # ── plan: decompose the brief into tasks.md ────────────────────────────────
+  create-tasks)
+    set_state create-tasks
+    run_claude -p "$(cat "${PROMPTS_DIR}/create-tasks.md")"
+
+    if [ -f "plan/ready/tasks.md" ]; then
+      echo ">>> tasks.md created"
+      safety_commit "chore: add demo plan (brief + tasks)"
+      clear_state; exit 1
+    fi
+    echo "!!! No tasks produced"; clear_state; exit 2
+    ;;
+
+  # ── change + test: execute ONE task, then verify-gate with rollback ────────
+  execute-tasks)
+    set_state execute-tasks
+    PRE_SHA=$(git rev-parse HEAD)
+
+    BEFORE=$(grep -c '^\- \[ \]' "plan/ready/tasks.md" || true); BEFORE=${BEFORE:-0}
+    run_claude --output-format stream-json -p "$(cat "${PROMPTS_DIR}/execute-tasks.md")"
+    AFTER=$(grep -c '^\- \[ \]' "plan/ready/tasks.md" || true); AFTER=${AFTER:-0}
+    echo ">>> Tasks remaining: ${BEFORE} -> ${AFTER}"
+
+    safety_commit "chore: progress on demo tasks"
+
+    # ── Pillar 03: rollback on test/build failure ──────────────────────────
+    if [ "$ROLLBACK_ON_FAILURE" = "true" ] && [ "$AFTER" -lt "$BEFORE" ]; then
+      echo ">>> Verify gate: ${GATE_CMD}"
+      set +e
+      bash -c "$GATE_CMD" > "${LOG_DIR}/gate-${TIMESTAMP}.log" 2>&1
+      GATE_RC=$?
+      set -e
+      if [ "$GATE_RC" -ne 0 ]; then
+        ROLL=$(cat plan/.rollback-count 2>/dev/null || echo 0)
+        TOTAL=$(cat plan/.rollback-total 2>/dev/null || echo 0)
+        echo $((TOTAL + 1)) > plan/.rollback-total
+        if [ "$ROLL" -ge "$MAX_ROLLBACKS" ]; then
+          echo "!!! Verify gate failed ${ROLL}x for this task — stuck (Loop of Death averted)"
+          rm -f plan/.rollback-count
+          clear_state; exit 2
+        fi
+        echo $((ROLL + 1)) > plan/.rollback-count
+        echo "!!! Verify gate FAILED — rolling back to ${PRE_SHA} (attempt $((ROLL + 1))/${MAX_ROLLBACKS})"
+        git reset --hard "$PRE_SHA"
+        clear_state; exit 1
+      fi
+      echo ">>> Verify gate passed"
+      rm -f plan/.rollback-count
+    fi
+
+    if [ "$AFTER" -eq 0 ]; then echo ">>> All tasks complete"; clear_state; exit 1; fi
+
+    # Stuck detection — no checkmark progress at all
+    if [ "$BEFORE" -eq "$AFTER" ]; then
+      STUCK_FILE="plan/.stuck-count"; STUCK=$(cat "$STUCK_FILE" 2>/dev/null || echo 0)
+      if [ "$STUCK" -ge 3 ]; then
+        echo "!!! No task progress after 3 retries — stuck"; rm -f "$STUCK_FILE"; clear_state; exit 2
+      fi
+      echo $((STUCK + 1)) > "$STUCK_FILE"
+      echo "!!! No progress — retry $((STUCK + 1))/3"; clear_state; exit 1
+    fi
+
+    rm -f plan/.stuck-count
+    clear_state; exit 1
+    ;;
+
+  # ── verify: full ci-check, screenshots, summary ────────────────────────────
+  verify)
+    set_state verify
+    safety_commit "chore: save progress before verify"
+
+    echo ">>> Running full ci-check.sh"
+    set +e
+    ./scripts/ci-check.sh 2>&1 | tee "${LOG_DIR}/ci-check-${TIMESTAMP}.log"
+    CI_RC=${PIPESTATUS[0]}
+    set -e
+
+    if [ "$CI_RC" -ne 0 ]; then
+      check_remediation_attempts "CI remediation"
+      CI_LOG=$(tail -200 "${LOG_DIR}/ci-check-${TIMESTAMP}.log")
+      run_claude -p "$(cat "${PROMPTS_DIR}/remediate.md")
+
+## CI failure output (tail)
+
+\`\`\`
+${CI_LOG}
+\`\`\`"
+      safety_commit "fix: ci remediation"
+      clear_state; exit 1
+    fi
+
+    echo ">>> CI passing"
+    rm -f plan/.fix-attempts
+
+    # Capture screenshots + confirm the feature works (once).
+    if [ ! -f "plan/.verified-once" ]; then
+      run_claude -p "$(cat "${PROMPTS_DIR}/verify.md")
+
+## Feature Request (from PROMPT.md)
+
+${FEATURE_REQUEST}"
+      safety_commit "docs: demo verification"
+      touch plan/.verified-once
+      clear_state; exit 1   # loop once more to re-confirm CI after any commits
+    fi
+
+    write_summary
+    touch plan/.verified
+    clear_state
+    echo ">>> Verified ✔  Branch ready: $(git rev-parse --abbrev-ref HEAD)"
+    exit 0
+    ;;
+
+  done)
+    echo ">>> Already complete"; exit 0 ;;
+
+esac

--- a/autonomous-demo/docker-compose.yml
+++ b/autonomous-demo/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: mmf
+      POSTGRES_PASSWORD: mmf
+      POSTGRES_DB: mmf
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U mmf']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  agent:
+    build: .
+    container_name: ${CONTAINER_NAME:-autonomous-demo}
+    env_file: .env
+    environment:
+      - DATABASE_URL=postgresql://mmf:mmf@db:5432/mmf?sslmode=disable
+      - JWT_SECRET=demo-jwt-secret
+      - MAX_ITERATIONS=${MAX_ITERATIONS:-30}
+      - COOLDOWN_SECONDS=${COOLDOWN_SECONDS:-3}
+      - TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-1800}
+    volumes:
+      # Bind-mount the actual repo so the agent edits REAL files — every change
+      # shows up live in your editor (VS Code) on a throwaway demo branch.
+      - ../:/workspace/repo
+      # Shadow every node_modules with a container-only named volume. This keeps
+      # the agent's Linux `npm ci` from wiping/overwriting your host's macOS
+      # node_modules. Source files are shared with the host; deps are not.
+      - demo_node_modules:/workspace/repo/node_modules
+      - demo_client_node_modules:/workspace/repo/packages/client/node_modules
+      - demo_server_node_modules:/workspace/repo/packages/server/node_modules
+      - demo_shared_node_modules:/workspace/repo/packages/shared/node_modules
+      # The feature request the agent will build.
+      - ./PROMPT.md:/workspace/PROMPT.md:ro
+      # Outputs land on the host for inspection after the run.
+      - ./logs:/workspace/logs
+      - ./screenshots:/screenshots
+    mem_limit: 4g
+    cpus: 2
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  demo_node_modules:
+  demo_client_node_modules:
+  demo_server_node_modules:
+  demo_shared_node_modules:

--- a/autonomous-demo/entrypoint.sh
+++ b/autonomous-demo/entrypoint.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ════════════════════════════════════════════════════════════════════════════
+#  Autonomous Agent in Docker — DEMO entrypoint
+#
+#  Pillar 01 (Containerise): this container holds the codebase, test suite and
+#  Playwright. Pillars 02/03/04 (Agent Loop / Guardrails / Observe) live in
+#  demo-loop.sh, which this script calls in a capped loop.
+# ════════════════════════════════════════════════════════════════════════════
+
+echo ">>> Autonomous demo starting"
+
+# ── Pillar 03: Guardrails (read from env, with safe defaults) ────────────────
+MAX_ITERATIONS="${MAX_ITERATIONS:-30}"   # hard cap on outer loop iterations
+COOLDOWN_SECONDS="${COOLDOWN_SECONDS:-3}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-1800}" # per Claude invocation (wall-clock)
+MAX_TURNS="${MAX_TURNS:-40}"             # cost guardrail: turns per invocation
+export MAX_ITERATIONS COOLDOWN_SECONDS TIMEOUT_SECONDS MAX_TURNS
+
+# ── Validate Claude auth ─────────────────────────────────────────────────────
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "!!! No Claude credentials. Set CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY)"
+  echo "!!! in autonomous-demo/.env (copy from .env.example)."
+  exit 1
+fi
+
+# ── Validate the feature request ─────────────────────────────────────────────
+PROMPT_FILE="/workspace/PROMPT.md"
+if [ ! -s "$PROMPT_FILE" ]; then
+  echo "!!! PROMPT.md is missing or empty."
+  echo "!!! Edit autonomous-demo/PROMPT.md with the feature you want built."
+  exit 1
+fi
+
+# ── Git identity + trust mounted/cloned dirs ─────────────────────────────────
+git config --global user.name  "${GIT_USER_NAME:-MMF Demo Agent}"
+git config --global user.email "${GIT_USER_EMAIL:-demo-agent@marsmissionfund.local}"
+git config --global --add safe.directory '*'
+
+# ── Smoke-test the Playwright MCP server ─────────────────────────────────────
+echo ">>> Smoke-testing Playwright MCP server..."
+node -e "require('/usr/lib/node_modules/@playwright/mcp/cli.js')" 2>/dev/null \
+  && echo ">>> MCP server module loads OK" \
+  || { echo "!!! Playwright MCP cli.js failed to load"; exit 1; }
+
+# ── Use the bind-mounted repo directly ───────────────────────────────────────
+# The repo is mounted read-write at /workspace/repo, so the agent edits the REAL
+# files on your host — you can watch every change in VS Code. node_modules are
+# shadowed by container-only volumes (see docker-compose.yml), so npm ci here
+# never touches your host's node_modules.
+REPO_DIR="/workspace/repo"
+if [ ! -d "$REPO_DIR/.git" ]; then
+  echo "!!! ${REPO_DIR} is not a git repo. Is the bind mount configured?"
+  exit 1
+fi
+cd "$REPO_DIR"
+
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+  echo "!!! Note: the repo has uncommitted changes. The agent will branch off the"
+  echo "!!! current HEAD and may sweep them into commits. For a clean demo, run"
+  echo "!!! from a clean checkout of main."
+fi
+
+# ── Pick a base ref for diffs, then branch off the current HEAD ───────────────
+if git show-ref --verify --quiet "refs/heads/main"; then
+  BASE_BRANCH="main"
+elif git show-ref --verify --quiet "refs/remotes/origin/main"; then
+  BASE_BRANCH="origin/main"
+else
+  BASE_BRANCH="$(git rev-parse HEAD)"
+fi
+export BASE_BRANCH
+
+BRANCH="${DEMO_BRANCH:-demo/$(date +%Y%m%d-%H%M%S)}"
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  git checkout "$BRANCH"
+else
+  git checkout -b "$BRANCH"
+fi
+echo ">>> Working on branch: ${BRANCH} (diffing against: ${BASE_BRANCH})"
+
+# ── Fix ownership of the container-only node_modules volumes ──────────────────
+# Docker creates named-volume mount points owned by root; the non-root `agent`
+# user can't write into them, so `npm ci` fails with EACCES. chown them first
+# (the agent has passwordless sudo). These are container-only volumes, so this
+# never affects your host's node_modules.
+for nm in node_modules packages/client/node_modules packages/server/node_modules packages/shared/node_modules; do
+  if [ -d "$nm" ]; then
+    sudo chown agent:agent "$nm" 2>/dev/null || true
+  fi
+done
+
+# ── Warm dependencies (codebase + test suite + Playwright) ───────────────────
+if [ -f package.json ]; then
+  echo ">>> Installing dependencies (npm ci)"
+  npm ci
+  echo ">>> Installing Chromium for the project's Playwright"
+  npx playwright install chromium
+fi
+
+# ── Database — for unit/E2E tests and visual verification ────────────────────
+export DATABASE_URL="${DATABASE_URL:-postgresql://mmf:mmf@db:5432/mmf?sslmode=disable}"
+export JWT_SECRET="${JWT_SECRET:-demo-jwt-secret}"
+echo ">>> Migrating database"
+dbmate -d packages/server/db/migrations -s packages/server/db/schema.sql up \
+  || echo "!!! dbmate migration failed (DB-dependent tests may fail)"
+
+# ── Announce guardrails (Pillar 03) ──────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════════════════"
+echo "  Autonomous demo — building from PROMPT.md"
+echo "  Guardrails:"
+echo "    • max iterations : ${MAX_ITERATIONS}"
+echo "    • max turns/call : ${MAX_TURNS}    (cost cap)"
+echo "    • timeout/call   : ${TIMEOUT_SECONDS}s"
+echo "    • rollback on test failure : ${ROLLBACK_ON_FAILURE:-true}"
+echo "════════════════════════════════════════════════════"
+
+# ── Pillar 02: the Agent Loop (analyse → change → test → verify → repeat) ─────
+iteration=0
+while [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
+  iteration=$((iteration + 1))
+  echo "--- Iteration ${iteration}/${MAX_ITERATIONS} ---"
+
+  exit_code=0
+  demo-loop.sh || exit_code=$?
+
+  if [ "$exit_code" -eq 0 ]; then
+    echo ">>> Demo complete 🎉"
+    break
+  elif [ "$exit_code" -eq 2 ]; then
+    # Pillar 04: this is the "Loop of Death" backstop — the agent is stuck.
+    echo "!!! Agent stuck (guardrail tripped). Stopping. See autonomous-demo/logs/."
+    break
+  fi
+
+  if [ "$iteration" -lt "$MAX_ITERATIONS" ]; then
+    echo ">>> Cooling down ${COOLDOWN_SECONDS}s..."
+    sleep "$COOLDOWN_SECONDS"
+  fi
+done
+
+if [ "$iteration" -ge "$MAX_ITERATIONS" ]; then
+  echo "!!! Reached iteration cap (${MAX_ITERATIONS}) — stopping (guardrail)."
+fi
+
+echo ""
+echo "=== Demo run finished (branch: ${BRANCH}) ==="
+echo "=== Inspect results in autonomous-demo/logs/ and autonomous-demo/screenshots/ ==="

--- a/autonomous-demo/prompts/create-brief.md
+++ b/autonomous-demo/prompts/create-brief.md
@@ -1,0 +1,67 @@
+# Create Brief
+
+You are the **Brief Author**. Read the feature request (appended at the end of
+this prompt), the project specs, and the codebase, then produce a concise
+implementation brief. **You do not write production code in this step.**
+
+## Process
+
+### Step 1: Gather context
+
+1. Read `./specs/learnings.md` if it exists — gotchas from previous runs.
+1. Read the **Feature Request** appended at the end of this prompt.
+1. Read the project specs — start with `./specs/README.md` and follow references.
+1. Explore the codebase to understand the current structure, components, and
+   patterns relevant to the request.
+
+### Step 2: Write the brief
+
+Create `plan/ready/brief.md` with this structure:
+
+```markdown
+# Brief: <feature title>
+
+## Goal
+
+One paragraph: what this feature delivers and why.
+
+## Scope
+
+- IN scope (bullets)
+- OUT of scope (bullets)
+
+## Approach
+
+High-level implementation strategy. Reference specific files, components, and
+patterns that already exist in the codebase.
+
+## Files to Create/Modify
+
+| File         | Action        | Description  |
+| ------------ | ------------- | ------------ |
+| path/to/file | create/modify | what changes |
+
+## Dependencies
+
+Any npm packages or prerequisite work needed.
+
+## Verification
+
+- Build/tests: `./scripts/ci-check.sh` passes
+- Visual: what to check in the browser at `http://localhost:5173`
+- E2E: user flows that deserve a Playwright spec
+```
+
+### Step 3: Self-review
+
+Critically review the brief for clarity, scope match (no gold-plating, nothing
+missing), feasibility (referenced files/patterns are correct), and completeness.
+Revise until another agent could implement it from the brief alone, then make
+sure the final version is saved at `plan/ready/brief.md`.
+
+## Output Format
+
+```text
+BRIEF_STATUS=approved
+BRIEF_PATH=plan/ready/brief.md
+```

--- a/autonomous-demo/prompts/create-brief.md
+++ b/autonomous-demo/prompts/create-brief.md
@@ -1,8 +1,11 @@
 # Create Brief
 
-You are the **Brief Author**. Read the feature request (appended at the end of
-this prompt), the project specs, and the codebase, then produce a concise
-implementation brief. **You do not write production code in this step.**
+You are the **Planning Agent**. Read the feature request (appended at the end of
+this prompt), the project specs, and the codebase, then produce a precise,
+structured implementation plan. **You do not write production code** — a separate
+Coding Agent will execute this plan and will see *only the files you write here*,
+not this conversation. Be explicit and unambiguous so it can execute without
+guessing.
 
 ## Process
 
@@ -35,6 +38,12 @@ One paragraph: what this feature delivers and why.
 High-level implementation strategy. Reference specific files, components, and
 patterns that already exist in the codebase.
 
+## Breaking Changes & Risks
+
+What this change could break — public APIs, shared types, DB schema, routes,
+cross-package contracts — and how to avoid regressions. Write "None expected"
+only if you are sure.
+
 ## Files to Create/Modify
 
 | File         | Action        | Description  |
@@ -45,11 +54,22 @@ patterns that already exist in the codebase.
 
 Any npm packages or prerequisite work needed.
 
-## Verification
+## Migration Steps
+
+The ordered sequence from the current state to the target state — the spine the
+task list will follow. For an upgrade/refactor, order the steps so the build
+stays green at each point (e.g. shared types → server → client). For a
+greenfield feature, the build order.
+
+## Verification Criteria
+
+The exact checks that must pass — name the commands:
 
 - Build/tests: `./scripts/ci-check.sh` passes
-- Visual: what to check in the browser at `http://localhost:5173`
+- Visual: what to check at `http://localhost:5173`, and which existing pages
+  must still work (no UI regressions)
 - E2E: user flows that deserve a Playwright spec
+  (`./scripts/run-e2e.sh e2e/<feature>.spec.ts`)
 ```
 
 ### Step 3: Self-review

--- a/autonomous-demo/prompts/create-tasks.md
+++ b/autonomous-demo/prompts/create-tasks.md
@@ -1,0 +1,103 @@
+# Create Tasks
+
+You are the **Task Planner** — you convert the approved brief into an ordered
+checklist of atomic, independently-verifiable tasks.
+
+## Input
+
+- `plan/ready/brief.md` — the approved implementation brief
+
+## Process
+
+### Step 1: Read the brief
+
+Read `plan/ready/brief.md` to understand the full scope of work.
+
+### Step 2: Decompose into tasks
+
+Break the brief into atomic tasks. Each task should:
+
+- Be completable in a single agent invocation (15–30 minutes of work)
+- Have clear inputs and outputs
+- Be independently verifiable (build, test, or visual check)
+- Build logically on the tasks before it
+
+### Step 3: Write the checklist
+
+Create `plan/ready/tasks.md` with this structure:
+
+```markdown
+# Tasks: <feature title>
+
+Brief: plan/ready/brief.md
+
+## Checklist
+
+- [ ] TASK-01: <short title>
+  - **Goal**: What this task accomplishes
+  - **Details**: Specific implementation instructions
+  - **Files**: Files to create or modify
+  - **Verify**: How to confirm this task is complete
+  - **Brief ref**: Which section of the brief this implements
+
+- [ ] TASK-02: <short title>
+      ...
+```
+
+### Guidelines
+
+- **Order matters**: each task builds on the previous one.
+- **First task**: usually setup, dependencies, or shared types.
+- **Last task**: usually integration plus a final verification pass.
+- **Granularity**: prefer more small tasks over fewer large ones.
+- **Every task needs a concrete Verify step** (a build, a test, or a visual check).
+- **No gaps**: the complete checklist must fully implement the brief.
+- **Co-locate routes and pages**: if a task adds a route that imports a page
+  component, the same task must create that component. Do NOT create
+  placeholder/stub files for later tasks — they cause `no-unused-vars` lint errors.
+
+### E2E tests — co-locate with feature tasks
+
+Do NOT create a single "write all E2E tests" task. Instead, for each task that
+adds a user-visible surface:
+
+- Add an E2E sub-step in the task's **Details**
+- The **Verify** step MUST include `./scripts/run-e2e.sh e2e/<feature>.spec.ts`
+  (a single file, not the whole suite)
+- The **Files** list MUST include the `e2e/<feature>.spec.ts` file
+
+After all feature tasks, add a final regression task:
+
+```text
+- [ ] TASK-LAST: Full verification
+  - **Goal**: Run the complete test suite and CI checks as a final gate
+  - **Details**: No new code — just run everything
+  - **Files**: (none)
+  - **Verify**: `./scripts/ci-check.sh` passes
+```
+
+For backend-only features with no UI, omit E2E tasks.
+
+### Screenshot task for frontend features
+
+When the brief's **Files to Create/Modify** table contains any path under
+`packages/client/src/`, insert this task immediately before the final
+verification task:
+
+```text
+- [ ] TASK-N: Visual verification screenshots
+  - **Goal**: Capture screenshots of every changed UI state
+  - **Details**: Start the dev server (and backend), use the Playwright MCP to
+    navigate to each affected page, take screenshots saved to
+    `/screenshots/TASK-{NN}.png`
+  - **Files**: (none — screenshots only)
+  - **Verify**: At least one `.png` exists under `/screenshots/`
+  - **Brief ref**: Verification section
+```
+
+## Output Format
+
+```text
+TASKS_CREATED=<count>
+TASKS_PATH=plan/ready/tasks.md
+```

--- a/autonomous-demo/prompts/create-tasks.md
+++ b/autonomous-demo/prompts/create-tasks.md
@@ -1,7 +1,11 @@
 # Create Tasks
 
-You are the **Task Planner** — you convert the approved brief into an ordered
-checklist of atomic, independently-verifiable tasks.
+You are the **Planning Agent** (step 2) — you convert the brief into an ordered
+checklist of atomic, independently-verifiable tasks that the **Coding Agent**
+will execute one at a time. Follow the brief's **Migration Steps** order, respect
+its **Breaking Changes & Risks**, and give every task an explicit **Verify**
+criterion (the tests/checks that must pass). The build must stay green after
+each task.
 
 ## Input
 

--- a/autonomous-demo/prompts/execute-tasks.md
+++ b/autonomous-demo/prompts/execute-tasks.md
@@ -1,0 +1,95 @@
+# Execute Tasks
+
+You are the **Implementation Agent** — you execute ONE task at a time from the
+checklist.
+
+**You write code. You verify it works. You mark it done. You STOP.**
+
+## Your Constraints
+
+- Execute exactly ONE unchecked task (`- [ ]`) per invocation — the first one.
+- Do NOT skip ahead or work on later tasks.
+- Do NOT refactor code unrelated to the current task.
+- Do NOT modify the task file except to check off the completed task.
+- Always run tests in the FOREGROUND so you can read the output immediately.
+- STOP after completing and committing one task.
+
+## Process
+
+### Step 1: Load context
+
+1. Read `./specs/learnings.md` if it exists.
+1. Read `./specs/README.md` for project standards (follow references as needed).
+1. Read `./plan/ready/brief.md` for the goal.
+1. Read `./plan/ready/tasks.md` and find the **first unchecked task** — that is
+   your assignment.
+1. Read any specs referenced in the task's **Brief ref**.
+
+### Step 2: Implement
+
+Implement the task per its **Goal**, **Details**, and **Files**. Follow project
+standards:
+
+- **TypeScript**: strict mode, no `any`
+- **React**: functional components, named exports
+- **Tailwind v4**: CSS-first config; components reference semantic design tokens
+  via `var()` — never hardcode colours
+- **Accessibility**: semantic HTML, focus-visible states
+
+When the task is (or includes) an E2E test, read `e2e/auth.spec.ts` and
+`e2e/campaigns.spec.ts` first and follow their patterns (`getByRole`,
+`getByLabel`, `test.describe`). Write standard Playwright Test code — do NOT use
+the Playwright MCP to author E2E specs.
+
+### Step 3: Verify
+
+Run `./scripts/ci-check.sh` before committing — it covers type-checking, lint,
+Prettier, build, and unit tests. Every check must pass. Do not cherry-pick
+individual checks. If anything fails, fix it and re-run until green.
+
+If the task's **Verify** step names an E2E spec, run exactly that command, e.g.
+`./scripts/run-e2e.sh e2e/<feature>.spec.ts`. Set a 10-minute (600000 ms)
+timeout on the Bash call and read the full output (do not pipe through `tail`).
+
+**Visual verification** (required when the task's **Files** include any path
+under `packages/client/src/`):
+
+1. Health-check the backend: `curl -sf http://localhost:3001/health` (or
+   `http://localhost:3001/v1/campaigns`). If it fails, start it with
+   `npm run dev:server &` and poll until ready.
+1. Start the dev server: `npm run dev &`
+1. Use the Playwright MCP to navigate to `http://localhost:5173`.
+1. Confirm the expected content renders.
+1. Take a screenshot saved to `/screenshots/TASK-{NN}.png`.
+1. Stop the background dev servers.
+
+The task is not complete unless the screenshot exists.
+
+### Step 4: Mark done
+
+1. Edit `plan/ready/tasks.md`: change `- [ ]` to `- [x]` for this task only.
+1. Stage all changed files (including the task file).
+1. Commit:
+
+   ```text
+   feat({scope}): {what was done}
+
+   TASK-{NN}: {task name}
+   ```
+
+1. **STOP** — do not start the next task.
+
+## Output Format
+
+```text
+TASK_COMPLETED=TASK-{NN}
+VERIFICATION={pass|fail}
+SCREENSHOT=/screenshots/TASK-{NN}.png (if applicable)
+NEXT_TASK=TASK-{NN+1} (or "none")
+```
+
+## Error Handling
+
+- Never mark a task done if its verification fails — fix it first.
+- If a task cannot be completed after 3 attempts, report the blocker and STOP.
+- If a predecessor task is not checked off, STOP and report the dependency gap.

--- a/autonomous-demo/prompts/execute-tasks.md
+++ b/autonomous-demo/prompts/execute-tasks.md
@@ -1,9 +1,11 @@
 # Execute Tasks
 
-You are the **Implementation Agent** — you execute ONE task at a time from the
-checklist.
+You are the **Coding Agent**. You receive a precise plan — the brief and task
+checklist written by the Planning Agent — not a vague instruction. Execute ONE
+task at a time from that checklist.
 
-**You write code. You verify it works. You mark it done. You STOP.**
+**You write code. You run the tests. You verify the UI still works. You mark the
+task done. You STOP.**
 
 ## Your Constraints
 
@@ -59,7 +61,8 @@ under `packages/client/src/`):
    `npm run dev:server &` and poll until ready.
 1. Start the dev server: `npm run dev &`
 1. Use the Playwright MCP to navigate to `http://localhost:5173`.
-1. Confirm the expected content renders.
+1. Confirm the expected content renders **and that the affected existing pages
+   still work** — the change must not break the UI.
 1. Take a screenshot saved to `/screenshots/TASK-{NN}.png`.
 1. Stop the background dev servers.
 

--- a/autonomous-demo/prompts/remediate.md
+++ b/autonomous-demo/prompts/remediate.md
@@ -1,0 +1,31 @@
+# Remediate CI
+
+You are the **CI Fixer**. The full `./scripts/ci-check.sh` failed. Your job is to
+make it pass.
+
+The failing output (tail) is appended at the end of this prompt.
+
+## Process
+
+1. Read the failure output and identify the root cause(s) — type errors, lint or
+   Prettier violations, failing unit tests, or a broken build.
+1. Fix the underlying problem. Do NOT disable checks, delete tests, lower
+   coverage thresholds, or add `eslint-disable` / `@ts-ignore` to paper over a
+   real failure.
+1. Re-run `./scripts/ci-check.sh` in the foreground and confirm it passes.
+1. Commit the fix:
+
+   ```text
+   fix: resolve CI failures
+
+   <one line on what was wrong>
+   ```
+
+1. STOP.
+
+## Output Format
+
+```text
+CI_STATUS={fixed|still-failing}
+SUMMARY=<one line>
+```

--- a/autonomous-demo/prompts/verify.md
+++ b/autonomous-demo/prompts/verify.md
@@ -1,0 +1,35 @@
+# Verify & Capture
+
+You are the **Verifier**. The full CI suite already passes. Your job is to prove
+the feature works end-to-end and capture evidence.
+
+The original feature request is appended at the end of this prompt.
+
+## Process
+
+1. Confirm every task in `plan/ready/tasks.md` is checked `[x]`. If any remain
+   unchecked, report it and STOP (do not implement — that is the loop's job).
+1. If the feature has a **user-visible surface** (any change under
+   `packages/client/src/`):
+   - Start the backend if needed: `npm run dev:server &` (poll until
+     `curl -sf http://localhost:3001/v1/campaigns` succeeds).
+   - Start the frontend: `npm run dev &`
+   - Use the Playwright MCP to navigate to the relevant page(s) at
+     `http://localhost:5173` and confirm the feature behaves as the request
+     describes.
+   - Take a screenshot of the working feature saved to
+     `/screenshots/VERIFY-{short-name}.png`.
+   - Stop the background dev servers.
+1. If the feature is **backend-only**, exercise the new endpoint(s) with `curl`
+   and confirm the responses match the request.
+
+Do NOT modify production code in this step — if something is broken, report it
+so the loop can route back to fixing it.
+
+## Output Format
+
+```text
+FEATURE_WORKS={yes|no}
+SCREENSHOTS=<comma-separated paths, or none>
+NOTES=<anything a reviewer should know>
+```

--- a/autonomous-demo/prompts/verify.md
+++ b/autonomous-demo/prompts/verify.md
@@ -16,7 +16,7 @@ The original feature request is appended at the end of this prompt.
    - Start the frontend: `npm run dev &`
    - Use the Playwright MCP to navigate to the relevant page(s) at
      `http://localhost:5173` and confirm the feature behaves as the request
-     describes.
+     describes **and that the affected existing pages have not regressed**.
    - Take a screenshot of the working feature saved to
      `/screenshots/VERIFY-{short-name}.png`.
    - Stop the background dev servers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,13 +137,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -162,21 +162,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -193,14 +193,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -210,14 +210,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -237,29 +237,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -309,27 +309,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -381,33 +381,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -415,14 +415,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2658,9 +2658,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3246,9 +3246,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3302,9 +3302,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3325,9 +3325,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -3345,11 +3345,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3438,9 +3438,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -4014,9 +4014,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "version": "1.5.375",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -4793,17 +4793,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5234,9 +5234,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7452,9 +7452,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -7506,11 +7506,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7839,9 +7842,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -8119,9 +8122,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -8139,7 +8142,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8323,9 +8326,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -8427,9 +8430,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -10339,9 +10342,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Adds a **self-contained `autonomous-demo/`** that runs an autonomous coding
agent against this repo entirely locally — no GitHub fork, upstream, or PRs
required (only a Claude token). It's the "watch it go" companion to the existing
`autonomous/` system, purpose-built for a live audience.

Drop a feature request into `PROMPT.md`, run `docker compose up`, and the agent
loops **analyse → change → test → verify → repeat**: writes a brief, decomposes
it into `tasks.md`, implements one task per iteration, runs `ci-check`, captures
Playwright screenshots, and writes a run summary.

## The four pillars (from the workshop slide)

- **Containerise** — Claude Code + Playwright MCP + dbmate + the repo in one image
- **Agent Loop** — a restart-safe state machine (`demo-loop.sh` + `prompts/`)
- **Guardrails** — iteration cap, per-call turn/cost cap, timeout, and
  **rollback on test failure** (`git reset --hard` when the verify gate fails)
- **Observe** — streamed state/guardrail logs plus `logs/` and `screenshots/`

## How it works

- The repo is **bind-mounted**, so the agent edits real files (visible live in
  VS Code) on a throwaway `demo/<timestamp>` branch.
- `node_modules` are **container-only named volumes**, so the host install is
  never touched (the entrypoint `chown`s them so the non-root agent can write).
- Ships with **Exercise 03 (Trending Missions)** as the default `PROMPT.md`, with
  Exercises 01 and 02 as ready-to-paste alternatives.

## What's included

```
autonomous-demo/
├── README.md            # full walkthrough: pillars, setup, prompt guide, troubleshooting
├── Dockerfile           # Claude Code + Playwright MCP + dbmate
├── docker-compose.yml   # agent + Postgres, bind mount + node_modules volumes
├── entrypoint.sh        # use mounted repo, install deps, migrate DB, run the loop
├── demo-loop.sh         # state machine + guardrails
├── prompts/             # create-brief · create-tasks · execute-tasks · remediate · verify
├── PROMPT.md            # the single input (example feature request)
└── .env.example / .gitignore / .dockerignore
```

## Testing

- `./scripts/ci-check.sh` passes (run by the pre-push hook).
- Smoke-tested end to end in Docker with a minimal `GET /v1/ping` prompt: the
  agent built the brief, generated `tasks.md`, added the route handler, and
  progressed through tasks under the guardrails.

## Notes

- Requires only Docker + a Claude credential (`CLAUDE_CODE_OAUTH_TOKEN`).
- Adds no application source code — only the `autonomous-demo/` tooling folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
